### PR TITLE
chore: remove environment variable debugging from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,16 +100,6 @@ jobs:
             
             # Stop and remove old containers (but keep volumes)
             docker compose -f compose.prod.yml down || true
-
-            # Print Environment Variables for Debugging
-            echo "=== Environment Variables ==="
-            echo "DB_USERNAME: $DB_USERNAME"
-            echo "DB_NAME: $DB_NAME"
-            echo "DB_PASSWORD: $DB_PASSWORD"
-            echo "MYSQL_ROOT_PASSWORD: $MYSQL_ROOT_PASSWORD"
-            echo "JWT_SECRET: $JWT_SECRET"
-            echo "JWT_EXPIRES_IN: $JWT_EXPIRES_IN"
-            echo "CORS_ORIGINS: $CORS_ORIGINS"
             
             # Start new containers
             docker compose -f compose.prod.yml up -d


### PR DESCRIPTION
## Description

Removed environment variable debugging echo statements from the deploy workflow to clean up deployment logs.

## Changes

- Removed debug echo statements that were printing environment variables during deployment

## Checklist

- [x] Tests passing locally
- [x] Lint checks passing
- [x] Documentation updated (if applicable)