### PR TITLE
refactor(auth): consume validated JWT/config

### DIFF
--- a/src/auth/auth.guard.spec.ts
+++ b/src/auth/auth.guard.spec.ts
@@ -23,7 +23,10 @@ describe('AuthGuard', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn(),
+            getOrThrow: jest.fn().mockReturnValue({
+              secret: 'jwt_secret',
+              expiresInSeconds: 3600,
+            }),
           },
         },
       ],
@@ -79,7 +82,6 @@ describe('AuthGuard', () => {
 
     it('should throw AuthenticationException when token verification fails', async () => {
       mockRequest.headers.authorization = 'Bearer validToken';
-      configService.get.mockReturnValue('jwt_secret');
       jwtService.verifyAsync.mockRejectedValue(new Error('Invalid token'));
 
       await expect(guard.canActivate(mockContext)).rejects.toThrow(
@@ -93,7 +95,6 @@ describe('AuthGuard', () => {
     it('should return true and set user in request when token is valid', async () => {
       const mockPayload = { sub: 1, username: 'testuser' };
       mockRequest.headers.authorization = 'Bearer validToken';
-      configService.get.mockReturnValue('jwt_secret');
       jwtService.verifyAsync.mockResolvedValue(mockPayload);
 
       const result = await guard.canActivate(mockContext);
@@ -103,7 +104,7 @@ describe('AuthGuard', () => {
       expect(jwtService.verifyAsync).toHaveBeenCalledWith('validToken', {
         secret: 'jwt_secret',
       });
-      expect(configService.get).toHaveBeenCalledWith('JWT_SECRET');
+      expect(configService.getOrThrow).toHaveBeenCalledWith('jwt');
     });
   });
 });

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -2,6 +2,7 @@ import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 import { ConfigService } from '@nestjs/config';
+import type { JwtConfig } from '@config/configuration.types';
 import { AuthenticationException } from '@core/exceptions';
 
 @Injectable()
@@ -21,7 +22,7 @@ export class AuthGuard implements CanActivate {
 
     try {
       request.user = await this.jwtService.verifyAsync(token, {
-        secret: this.configService.get<string>('JWT_SECRET'),
+        secret: this.configService.getOrThrow<JwtConfig>('jwt').secret,
       });
     } catch (error) {
       throw new AuthenticationException(

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -43,11 +43,14 @@ describe('AuthService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockImplementation((key: string) => {
-              const config = {
-                JWT_SECRET: 'test-secret',
-              };
-              return config[key];
+            getOrThrow: jest.fn((key: string) => {
+              if (key === 'jwt') {
+                return {
+                  secret: 'test-secret',
+                  expiresInSeconds: 3600,
+                };
+              }
+              throw new Error(`unknown ${key}`);
             }),
           },
         },
@@ -168,7 +171,10 @@ describe('AuthService', () => {
 
       usersService.findOneByEmail.mockResolvedValue(user);
       jwtService.signAsync.mockResolvedValue('fake-jwt-token');
-      configService.get.mockReturnValue(3600); // 1 hour
+      configService.getOrThrow.mockReturnValue({
+        secret: 'test-secret',
+        expiresInSeconds: 3600,
+      });
 
       const result = await service.login(user.email, password);
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '@users/users.service';
 import { RegisterDto } from '@auth/dto/register.dto';
 import { ConfigService } from '@nestjs/config';
+import type { JwtConfig } from '@config/configuration.types';
 import { User } from '@users/entities/user.entity';
 import {
   ConflictException,
@@ -73,7 +74,9 @@ export class AuthService {
     return {
       access_token: access_token,
       expires_at: new Date(
-        Date.now() + this.configService.get<number>('JWT_EXPIRES_IN') * 1000,
+        Date.now() +
+          this.configService.getOrThrow<JwtConfig>('jwt').expiresInSeconds *
+            1000,
       ),
       user: {
         id: user.id,

--- a/src/auth/jwt.config.spec.ts
+++ b/src/auth/jwt.config.spec.ts
@@ -1,26 +1,22 @@
 import { ConfigService } from '@nestjs/config';
 import { jwtConfigFactory } from './jwt.config';
+import type { JwtConfig } from '@config/configuration.types';
 
 describe('jwtConfigFactory', () => {
   let mockConfigService: jest.Mocked<ConfigService>;
 
   beforeEach(() => {
     mockConfigService = {
-      get: jest.fn(),
       getOrThrow: jest.fn(),
     } as unknown as jest.Mocked<ConfigService>;
   });
 
   it('should return correct JWT config', async () => {
-    // Mock successful responses
-    mockConfigService.get.mockImplementation((key: string) => {
-      if (key === 'JWT_SECRET') return 'my-secret';
-      return null;
-    });
-    mockConfigService.getOrThrow.mockImplementation((key: string) => {
-      if (key === 'JWT_EXPIRES_IN') return '3600';
-      throw new Error('Key not found');
-    });
+    const jwt: JwtConfig = {
+      secret: 'my-secret',
+      expiresInSeconds: 3600,
+    };
+    mockConfigService.getOrThrow.mockReturnValue(jwt);
 
     const config = await jwtConfigFactory(mockConfigService);
 
@@ -29,30 +25,27 @@ describe('jwtConfigFactory', () => {
       signOptions: { expiresIn: '3600s' },
     });
 
-    expect(mockConfigService.get).toHaveBeenCalledWith('JWT_SECRET');
-    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith('JWT_EXPIRES_IN');
+    expect(mockConfigService.getOrThrow).toHaveBeenCalledWith('jwt');
   });
 
-  it('should use undefined as secret when JWT_SECRET is not defined', async () => {
-    // Mock missing JWT_SECRET
-    mockConfigService.get.mockReturnValue(undefined);
-    mockConfigService.getOrThrow.mockReturnValue('3600');
-
-    const config = await jwtConfigFactory(mockConfigService);
-
-    expect(config.secret).toBeUndefined();
-    expect(config.signOptions.expiresIn).toBe('3600s');
-  });
-
-  it('should throw error when JWT_EXPIRES_IN is not defined', async () => {
-    // Mock successful JWT_SECRET but missing JWT_EXPIRES_IN
-    mockConfigService.get.mockReturnValue('my-secret');
-    mockConfigService.getOrThrow.mockImplementation(() => {
-      throw new Error('Config key "JWT_EXPIRES_IN" is not defined');
+  it('should throw when JWT secret is empty', async () => {
+    mockConfigService.getOrThrow.mockReturnValue({
+      secret: '',
+      expiresInSeconds: 3600,
     });
 
     await expect(jwtConfigFactory(mockConfigService)).rejects.toThrow(
-      'Config key "JWT_EXPIRES_IN" is not defined',
+      'JWT_SECRET is not set',
+    );
+  });
+
+  it('should throw when jwt namespace is missing', async () => {
+    mockConfigService.getOrThrow.mockImplementation(() => {
+      throw new Error('Config key "jwt" is not defined');
+    });
+
+    await expect(jwtConfigFactory(mockConfigService)).rejects.toThrow(
+      'Config key "jwt" is not defined',
     );
   });
 });

--- a/src/auth/jwt.config.ts
+++ b/src/auth/jwt.config.ts
@@ -1,21 +1,18 @@
 import { ConfigService } from '@nestjs/config';
+import type { JwtConfig } from '@config/configuration.types';
 
 /**
- * Factory function that creates JWT configuration options
- *
- * This function is used by the JwtModule to configure JWT token generation.
- * It reads the JWT_SECRET and JWT_EXPIRES_IN environment variables to set
- * the secret key and token expiration time.
- *
- * @param configService - The NestJS ConfigService for accessing environment variables
- * @returns JWT module configuration object with secret and sign options
- * @throws Error if required environment variables are missing
+ * Opciones para JwtModule (secreto y expiración).
  */
 export async function jwtConfigFactory(configService: ConfigService) {
+  const jwt = configService.getOrThrow<JwtConfig>('jwt');
+  if (!jwt.secret?.length) {
+    throw new Error('JWT_SECRET is not set');
+  }
   return {
-    secret: configService.get<string>('JWT_SECRET'),
+    secret: jwt.secret,
     signOptions: {
-      expiresIn: configService.getOrThrow<string>('JWT_EXPIRES_IN') + 's',
+      expiresIn: `${jwt.expiresInSeconds}s`,
     },
   };
 }

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -8,11 +8,12 @@ describe('JwtStrategy', () => {
   let configService: jest.Mocked<ConfigService>;
 
   beforeEach(async () => {
-    // Mock the ConfigService
     const mockConfigService = {
-      get: jest.fn((key: string) => {
-        if (key === 'JWT_SECRET') return 'test_jwt_secret';
-        return undefined;
+      getOrThrow: jest.fn((key: string) => {
+        if (key === 'jwt') {
+          return { secret: 'test_jwt_secret', expiresInSeconds: 3600 };
+        }
+        throw new Error(`unknown key ${key}`);
       }),
     };
 
@@ -36,39 +37,31 @@ describe('JwtStrategy', () => {
 
   describe('constructor', () => {
     it('should configure the strategy with correct options', () => {
-      // This test verifies that the strategy is configured correctly
-      // We can't directly test the super() call, but we can test that the ConfigService was called
-      expect(configService.get).toHaveBeenCalledWith('JWT_SECRET');
+      expect(configService.getOrThrow).toHaveBeenCalledWith('jwt');
     });
   });
 
   describe('validate', () => {
     it('should return the payload', async () => {
-      // Create a mock payload
       const mockPayload: AccessTokenPayload = {
         userId: '123e4567-e89b-12d3-a456-426614174000' as any,
         email: 'test@example.com',
       };
 
-      // Call the validate method
       const result = await strategy.validate(mockPayload);
 
-      // Verify that the method returns the payload
       expect(result).toEqual(mockPayload);
     });
 
     it('should handle payloads with additional properties', async () => {
-      // Create a mock payload with additional properties
       const mockPayload = {
         userId: '123e4567-e89b-12d3-a456-426614174000' as any,
         email: 'test@example.com',
         additionalProp: 'value',
       };
 
-      // Call the validate method
       const result = await strategy.validate(mockPayload as any);
 
-      // Verify that the method returns the entire payload
       expect(result).toEqual(mockPayload);
     });
   });

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import type { JwtConfig } from '@config/configuration.types';
 import { AccessTokenPayload } from '@auth/types/AccessTokenPayload';
 
 @Injectable()
@@ -10,7 +11,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get<string>('JWT_SECRET'),
+      secretOrKey: configService.getOrThrow<JwtConfig>('jwt').secret,
     });
   }
 


### PR DESCRIPTION
## Summary
Refactors **authentication and JWT** to consume the validated configuration from **#60** (JWT secret, expiry, etc.) instead of ad-hoc env reads.

## Depends on
- **#60** (`feat/validated-config`) — merge base for this PR.

## Changes
- `JwtModule` registration, `JwtStrategy`, guards, and `AuthService` aligned with validated config.
- Unit tests updated (`jwt.config`, strategies, guards, auth service specs).

## Why
- Consistent config source; fewer env typos and runtime surprises.

## How to verify
```bash
yarn test --testPathPattern=auth
yarn test
```
