### PR TITLE
🔒 feat(security): Helmet, remove query param API keys, prevent user enumeration

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "express": "^5.1.0",
+    "helmet": "^8.1.0",
     "mysql2": "^3.14.1",
     "nestjs-cls": "^6.2.0",
     "passport": "^0.7.0",

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -125,12 +125,12 @@ describe('AuthService', () => {
       expect(result).toEqual(user);
     });
 
-    it('should throw if user not found', async () => {
+    it('should throw AuthenticationException if user not found (prevents enumeration)', async () => {
       usersService.findOneByEmail.mockResolvedValue(undefined);
 
       await expect(
         service.validateUser('notfound@mail.com', password),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(AuthenticationException);
     });
 
     it('should throw if password does not match', async () => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -95,11 +95,12 @@ export class AuthService {
   async validateUser(email: string, password: string): Promise<User> {
     const user: User = await this.usersService.findOneByEmail(email);
     if (!user) {
-      throw new NotFoundException('User not found');
+      // Same error message as invalid password to prevent user enumeration
+      throw new AuthenticationException('Invalid email or password');
     }
     const isMatch: boolean = await bcryptjs.compare(password, user.password);
     if (!isMatch) {
-      throw new AuthenticationException('Invalid credentials');
+      throw new AuthenticationException('Invalid email or password');
     }
     return user;
   }

--- a/src/core/api-key.guard.spec.ts
+++ b/src/core/api-key.guard.spec.ts
@@ -19,6 +19,15 @@ describe('ApiKeyGuard', () => {
     await expect(guard.canActivate(context)).rejects.toThrow();
   });
 
+  it('should not accept API key from query params', async () => {
+    const context: any = {
+      switchToHttp: () => ({
+        getRequest: () => ({ headers: {}, query: { api_key: 'from-query' } }),
+      }),
+    };
+    await expect(guard.canActivate(context)).rejects.toThrow();
+  });
+
   it('should throw if key is invalid', async () => {
     (apiKeyService.validate as jest.Mock).mockResolvedValue(false);
     const context: any = {

--- a/src/core/api-key.guard.ts
+++ b/src/core/api-key.guard.ts
@@ -8,9 +8,9 @@ export class ApiKeyGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    // Accept API key from header `x-api-key`, Authorization header as `ApiKey <key>`,
-    // or query param `api_key` for flexibility when calling from curl or browsers.
-    let apiKey = request.headers['x-api-key'] || request.query?.api_key;
+    // Accept API key from header `x-api-key` or Authorization header as `ApiKey <key>`.
+    // Query param removed to prevent keys leaking in URLs, logs, and browser history.
+    let apiKey = request.headers['x-api-key'];
     if (!apiKey) {
       const authHeader =
         request.headers['authorization'] || request.headers['Authorization'];

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,25 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from '@nestjs/common';
 import { ValidationPipe } from '@core';
 import { loadAppConfig } from '@config/configuration.loaders';
+import helmet from 'helmet';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const appConfig = loadAppConfig();
+
+  // Security headers — CSP configured to allow Swagger UI
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: [`'self'`],
+          styleSrc: [`'self'`, `'unsafe-inline'`],
+          imgSrc: [`'self'`, 'data:', 'validator.swagger.io'],
+          scriptSrc: [`'self'`, `https: 'unsafe-inline'`],
+        },
+      },
+    }),
+  );
 
   app.enableCors({
     origin: (origin, callback) => {

--- a/test/helmet.e2e-spec.ts
+++ b/test/helmet.e2e-spec.ts
@@ -1,0 +1,60 @@
+import * as express from 'express';
+import * as request from 'supertest';
+import helmet from 'helmet';
+
+/**
+ * Verifies that Helmet security headers are correctly configured
+ * with CSP directives that allow Swagger UI.
+ *
+ * Uses a standalone Express app to test Helmet in isolation,
+ * without needing the full NestJS app or database.
+ */
+describe('Helmet Security Headers (e2e)', () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = (express as any)();
+    app.use(
+      helmet({
+        contentSecurityPolicy: {
+          directives: {
+            defaultSrc: [`'self'`],
+            styleSrc: [`'self'`, `'unsafe-inline'`],
+            imgSrc: [`'self'`, 'data:', 'validator.swagger.io'],
+            scriptSrc: [`'self'`, `https: 'unsafe-inline'`],
+          },
+        },
+      }),
+    );
+    app.get('/test', (_req: any, res: any) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should include X-Content-Type-Options header', async () => {
+    const res = await request(app).get('/test');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('should include X-Frame-Options header', async () => {
+    const res = await request(app).get('/test');
+    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
+  });
+
+  it('should include Content-Security-Policy header', async () => {
+    const res = await request(app).get('/test');
+    expect(res.headers['content-security-policy']).toBeDefined();
+    expect(res.headers['content-security-policy']).toContain("default-src 'self'");
+    expect(res.headers['content-security-policy']).toContain("style-src 'self' 'unsafe-inline'");
+  });
+
+  it('should not include X-Powered-By header', async () => {
+    const res = await request(app).get('/test');
+    expect(res.headers['x-powered-by']).toBeUndefined();
+  });
+
+  it('should include Strict-Transport-Security header', async () => {
+    const res = await request(app).get('/test');
+    expect(res.headers['strict-transport-security']).toBeDefined();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,6 +4612,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"helmet@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "helmet@npm:8.1.0"
+  checksum: 10c0/94d3a7ebc88dbda1421635bdf33f00724adb5252269e93c5ab296ec0db11336d01265659ad3739ab1a1e881fb23a686ff7e788aac6a5fb929285134f157df763
+  languageName: node
+  linkType: hard
+
 "hookified@npm:^1.14.0":
   version: 1.15.1
   resolution: "hookified@npm:1.15.1"
@@ -6654,6 +6661,7 @@ __metadata:
     eslint: "npm:^9.28.0"
     eslint-config-prettier: "npm:^10.1.5"
     express: "npm:^5.1.0"
+    helmet: "npm:^8.1.0"
     jest: "npm:^29.x"
     mysql2: "npm:^3.14.1"
     nestjs-cls: "npm:^6.2.0"


### PR DESCRIPTION
## Summary

Three security improvements in one PR:

- 🛡️ **Helmet security headers** (#41): XSS protection, HSTS, X-Frame-Options, etc. CSP configured to allow Swagger UI.
- 🔑 **Remove API key from query params** (#44): Only `x-api-key` header and `Authorization: ApiKey <key>` accepted. Prevents keys leaking in URLs, logs, and browser history.
- 🔐 **Prevent user enumeration** (#42): Login returns same error message for "user not found" and "wrong password" — `Invalid email or password`.

Closes #41
Closes #44
Closes #42

## Test plan

- [ ] Verify response headers include Helmet security headers (X-Frame-Options, X-Content-Type-Options, etc.)
- [ ] Verify Swagger UI loads correctly at `/docs`
- [ ] Verify `?api_key=xxx` in query params is rejected
- [ ] Verify `x-api-key` header still works
- [ ] Verify login with wrong email returns "Invalid email or password"
- [ ] Verify login with wrong password returns same message