### PR TITLE
🔥 chore(deps): remove redundant bcryptjs, unify on bcrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/passport-jwt": "^4.0.1",
     "axios": "^1.10.x",
     "bcrypt": "^6.0.0",
-    "bcryptjs": "^3.0.2",
     "cache-manager": "^7.2.8",
     "cache-manager-redis-yet": "^5.1.5",
     "class-transformer": "^0.5.1",

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '@users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import * as bcryptjs from 'bcryptjs';
+import * as bcrypt from 'bcrypt';
 import { RegisterDto } from './dto/register.dto';
 import { User } from '@users/entities/user.entity';
 import {
@@ -22,7 +22,7 @@ describe('AuthService', () => {
   let hashedPassword: string;
 
   beforeAll(async () => {
-    hashedPassword = await bcryptjs.hash(password, 10);
+    hashedPassword = await bcrypt.hash(password, 10);
   });
 
   beforeEach(async () => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import * as bcryptjs from 'bcryptjs';
+import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '@users/users.service';
 import { RegisterDto } from '@auth/dto/register.dto';
@@ -37,7 +37,7 @@ export class AuthService {
     if (existingUser) {
       throw new ConflictException('Email already exists');
     }
-    const hashedPassword = await bcryptjs.hash(payload.password, 10);
+    const hashedPassword = await bcrypt.hash(payload.password, 10);
 
     return await this.usersService.create({
       username: payload.username,
@@ -97,7 +97,7 @@ export class AuthService {
     if (!user) {
       throw new NotFoundException('User not found');
     }
-    const isMatch: boolean = await bcryptjs.compare(password, user.password);
+    const isMatch: boolean = await bcrypt.compare(password, user.password);
     if (!isMatch) {
       throw new AuthenticationException('Invalid credentials');
     }

--- a/src/database/seeder.prod.ts
+++ b/src/database/seeder.prod.ts
@@ -2,7 +2,7 @@ import AppDataSource from '@config/typeorm.config.prod';
 import { User } from '@users/entities/user.entity';
 import { Project } from '@projects/entities/project.entity';
 import { Contact } from '@contacts/entities/contact.entity';
-import * as bcryptjs from 'bcryptjs';
+import * as bcrypt from 'bcrypt';
 
 async function seed() {
   try {
@@ -18,7 +18,7 @@ async function seed() {
     await userRepo.clear();
 
     // Users
-    const password = await bcryptjs.hash(process.env.DEFAULT_USER_PASSWORD, 10);
+    const password = await bcrypt.hash(process.env.DEFAULT_USER_PASSWORD, 10);
     const users = [
       userRepo.create({
         username: 'admin',

--- a/src/database/seeder.ts
+++ b/src/database/seeder.ts
@@ -2,7 +2,7 @@ import AppDataSource from '@config/typeorm.config';
 import { User } from '@users/entities/user.entity';
 import { Project } from '@projects/entities/project.entity';
 import { Contact } from '@contacts/entities/contact.entity';
-import * as bcryptjs from 'bcryptjs';
+import * as bcrypt from 'bcrypt';
 
 async function seed() {
   try {
@@ -18,7 +18,7 @@ async function seed() {
     await userRepo.clear();
 
     // Users
-    const password = await bcryptjs.hash('password123', 10);
+    const password = await bcrypt.hash('password123', 10);
     const users = [
       userRepo.create({
         username: 'testuser',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,15 +2838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcryptjs@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "bcryptjs@npm:3.0.2"
-  bin:
-    bcrypt: bin/bcrypt
-  checksum: 10c0/a0923cac99f83e913f8f4e4f42df6a27c6593b24d509900331d1280c4050b1544e602a0ac67b43f7bb5c969991c3ed77fd72f19b7dc873be8ee794da3d925c7e
-  languageName: node
-  linkType: hard
-
 "bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -6646,7 +6637,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.34.0"
     axios: "npm:^1.10.x"
     bcrypt: "npm:^6.0.0"
-    bcryptjs: "npm:^3.0.2"
     cache-manager: "npm:^7.2.8"
     cache-manager-redis-yet: "npm:^5.1.5"
     class-transformer: "npm:^0.5.1"


### PR DESCRIPTION
## Summary

- Remove `bcryptjs` dependency, unify all hashing on native `bcrypt` (faster, native bindings)
- Updated imports in auth service, seeders, and tests

Closes #47

**Note:** #45 (Index on User.email) is already resolved — `unique: true` on the entity creates the index automatically. Will close separately.

## Test plan

- [ ] Verify auth tests pass (login, register, validateUser)
- [ ] Verify seeders work with `bcrypt`