### PR TITLE
🔒 feat(auth): add password strength validation to register

### DIFF
--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, IsStrongPassword, MinLength } from 'class-validator';
 
 export class RegisterDto {
   @IsString()
@@ -12,9 +12,23 @@ export class RegisterDto {
   @ApiProperty({ description: 'User Email' })
   email: string;
 
-  @IsString()
-  @MinLength(6)
-  @ApiProperty({ description: 'User Password' })
+  @IsStrongPassword(
+    {
+      minLength: 8,
+      minLowercase: 1,
+      minUppercase: 1,
+      minNumbers: 1,
+      minSymbols: 0,
+    },
+    {
+      message:
+        'Password must be at least 8 characters with uppercase, lowercase, and number',
+    },
+  )
+  @ApiProperty({
+    description:
+      'User Password (min 8 chars, must include uppercase, lowercase, and number)',
+  })
   @Transform(({ value }) => value.trim())
   password: string;
 }


### PR DESCRIPTION
## Summary

Adds `@IsStrongPassword()` to `RegisterDto` requiring:
- Min 8 characters
- At least 1 uppercase letter
- At least 1 lowercase letter
- At least 1 number

Clear error message: "Password must be at least 8 characters with uppercase, lowercase, and number"

Closes #50

## Test plan

- [ ] `POST /auth/register` with weak password (e.g. "123456") returns 422 with validation error
- [ ] `POST /auth/register` with strong password (e.g. "MyPass123") succeeds
- [ ] Swagger docs show password requirements in description