### PR TITLE
✨ feat(config): expand validation + move DeleteResponseDto to @core

### DIFF
--- a/src/config/validate-configuration.ts
+++ b/src/config/validate-configuration.ts
@@ -1,8 +1,19 @@
-import type { JwtConfig } from '@config/configuration.types';
+import type {
+  DatabaseConfig,
+  JwtConfig,
+  RedisConfig,
+} from '@config/configuration.types';
+
+interface ValidationRule {
+  condition: boolean;
+  message: string;
+}
 
 /**
- * Valida la config ensamblada tras los `registerAs`.
- * En `test` no exige secretos para no romper Jest.
+ * Validates assembled config after `registerAs` loaders.
+ * - In `test` mode: skips all checks (Jest doesn't need real secrets).
+ * - In `production`: throws on missing required vars.
+ * - In `development`: logs warnings but doesn't throw.
  */
 export function validateConfiguration(
   config: Record<string, unknown>,
@@ -14,14 +25,35 @@ export function validateConfiguration(
     return config;
   }
 
+  const db = config.database as DatabaseConfig | undefined;
   const jwt = config.jwt as JwtConfig | undefined;
-  if (nodeEnv === 'production' && !jwt?.secret?.length) {
-    throw new Error('Configuration: JWT_SECRET is required in production');
-  }
+  const redis = config.redis as RedisConfig | undefined;
+  const apiKey = config.apiKey as { secret?: string } | undefined;
 
-  const db = config.database as { host?: string } | undefined;
-  if (nodeEnv === 'production' && !db?.host?.length) {
-    throw new Error('Configuration: DB_HOST is required in production');
+  const rules: ValidationRule[] = [
+    { condition: !jwt?.secret?.length, message: 'JWT_SECRET is required' },
+    { condition: !db?.host?.length, message: 'DB_HOST is required' },
+    { condition: !db?.username?.length, message: 'DB_USERNAME is required' },
+    { condition: !db?.database?.length, message: 'DB_NAME is required' },
+    { condition: !redis?.host?.length, message: 'REDIS_HOST is required' },
+    {
+      condition: !apiKey?.secret?.length,
+      message: 'API_KEY_SECRET is required',
+    },
+  ];
+
+  const errors = rules.filter((r) => r.condition).map((r) => r.message);
+
+  if (errors.length > 0) {
+    if (nodeEnv === 'production') {
+      throw new Error(
+        `Configuration errors:\n${errors.map((e) => `  - ${e}`).join('\n')}`,
+      );
+    }
+    // Development: warn but don't crash
+    for (const error of errors) {
+      console.warn(`[Config Warning] ${error}`);
+    }
   }
 
   return config;

--- a/src/core/dto/delete-response.dto.ts
+++ b/src/core/dto/delete-response.dto.ts
@@ -1,0 +1,20 @@
+import { SingleResourceResponseDto } from './single-resource-response.dto';
+
+/**
+ * DTO for delete operation response
+ *
+ * Uses SingleResourceResponseDto base class to eliminate code duplication.
+ * Delete responses don't include pagination metadata.
+ */
+export class DeleteResponseDto extends SingleResourceResponseDto<{
+  message: string;
+}> {
+  /**
+   * Create a DeleteResponseDto with a success message
+   * @param message Success message
+   * @returns DeleteResponseDto
+   */
+  static withMessage(message: string): DeleteResponseDto {
+    return new DeleteResponseDto({ message });
+  }
+}

--- a/src/core/dto/index.ts
+++ b/src/core/dto/index.ts
@@ -4,3 +4,4 @@ export * from './error-response.dto';
 export * from './single-resource-response.dto';
 export * from './pagination-query.dto';
 export * from './paginated-response.dto';
+export * from './delete-response.dto';

--- a/src/core/services/base-crud.service.ts
+++ b/src/core/services/base-crud.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Repository, FindOptionsWhere, DeepPartial } from 'typeorm';
 import { NotFoundException } from '@core/exceptions/not-found.exception';
-import { DeleteResponseDto } from '@projects/dto/delete-response.dto';
+import { DeleteResponseDto } from '@core/dto';
 
 /**
  * Base CRUD service for common database operations

--- a/src/projects/dto/delete-response.dto.ts
+++ b/src/projects/dto/delete-response.dto.ts
@@ -1,20 +1,2 @@
-import { SingleResourceResponseDto } from '@core/dto';
-
-/**
- * DTO for delete operation response
- *
- * Uses SingleResourceResponseDto base class to eliminate code duplication.
- * Delete responses don't include pagination metadata.
- */
-export class DeleteResponseDto extends SingleResourceResponseDto<{
-  message: string;
-}> {
-  /**
-   * Create a DeleteResponseDto with a success message
-   * @param message Success message
-   * @returns DeleteResponseDto
-   */
-  static withMessage(message: string): DeleteResponseDto {
-    return new DeleteResponseDto({ message });
-  }
-}
+// Re-export from @core/dto for backwards compatibility
+export { DeleteResponseDto } from '@core/dto';


### PR DESCRIPTION
## Summary

Two improvements:

### Expand startup validation (#64)
- **Production**: throws with all missing vars listed (JWT_SECRET, DB_HOST, DB_USERNAME, DB_NAME, REDIS_HOST, API_KEY_SECRET)
- **Development**: warns but doesn't crash
- **Test**: skips validation entirely

### Move DeleteResponseDto to @core (#54)
- Moved `DeleteResponseDto` from `@projects/dto` to `@core/dto`
- Breaks circular dependency: `@core/services/base-crud.service.ts` no longer imports from `@projects`
- Old location re-exports for backwards compatibility

Closes #64
Closes #54

## Test plan

- [ ] App starts in development with missing vars (logs warnings)
- [ ] App refuses to start in production with missing vars
- [ ] All projects and contacts tests pass (63 tests)
- [ ] No `@core → @projects` imports remain