### PR TITLE
🌐 feat(api): add global prefix /api/v1

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,11 @@ async function bootstrap() {
     exposedHeaders: ['Content-Range', 'X-Content-Range'],
   });
 
+  // Global API prefix for versioning
+  app.setGlobalPrefix('api/v1', {
+    exclude: ['health', 'docs'],
+  });
+
   // Set up global pipes
   // Note: Interceptors and filters are registered in AppModule using APP_INTERCEPTOR
   // and APP_FILTER tokens for proper DI support


### PR DESCRIPTION
## Summary

Adds `app.setGlobalPrefix('api/v1')` for API versioning. Health and docs endpoints excluded.

- `/projects` → `/api/v1/projects`
- `/auth/login` → `/api/v1/auth/login`
- `/health` → `/health` (unchanged)
- `/docs` → `/docs` (unchanged)

Closes #43

## ⚠️ Breaking Change

All API endpoints now require `/api/v1/` prefix. Frontend clients must update their base URL.

## Test plan

- [ ] `GET /api/v1/projects` returns projects
- [ ] `GET /projects` returns 404
- [ ] `GET /health` still works without prefix
- [ ] Swagger at `/docs` still works