### PR TITLE
♻️ feat(database): implement soft delete with restore (#53)

### DIFF
--- a/src/contacts/contacts.service.spec.ts
+++ b/src/contacts/contacts.service.spec.ts
@@ -274,13 +274,13 @@ describe('ContactsService', () => {
         .spyOn(repository, 'findOne')
         .mockResolvedValue(existingContact as any);
       jest
-        .spyOn(repository, 'delete')
-        .mockResolvedValue({ affected: 1 } as any);
+        .spyOn(repository, 'softRemove')
+        .mockResolvedValue(existingContact as any);
 
       const result = await service.remove(1);
 
       expect(result.data.message).toBe('Contact successfully deleted');
-      expect(logSpy).toHaveBeenCalledWith(`Deleted contact with ID 1`);
+      expect(logSpy).toHaveBeenCalledWith(`Soft-deleted contact with ID 1`);
     });
 
     it('should throw NotFoundException if contact not found', async () => {

--- a/src/core/services/base-crud.service.ts
+++ b/src/core/services/base-crud.service.ts
@@ -110,14 +110,13 @@ export abstract class BaseCrudService<
   }
 
   /**
-   * Deletes an entity by its ID
+   * Soft-deletes an entity by its ID (sets deletedAt timestamp)
    *
    * @param id - The ID of the entity to delete
    * @returns Promise resolving to a standardized response with a success message
    * @throws NotFoundException if the entity doesn't exist
    */
   async remove(id: number): Promise<DeleteResponseDto> {
-    // Check if the entity exists
     const existingEntity = await this.repository.findOne({
       where: { id } as FindOptionsWhere<TEntity>,
     });
@@ -129,24 +128,40 @@ export abstract class BaseCrudService<
       );
     }
 
-    // Delete entity
-    const result = await this.repository.delete(id);
+    await this.repository.softRemove(existingEntity);
+
+    this.logger.log(
+      `Soft-deleted ${this.getEntityName().toLowerCase()} with ID ${id}`,
+    );
+    return DeleteResponseDto.withMessage(
+      `${this.getEntityName()} successfully deleted`,
+    );
+  }
+
+  /**
+   * Restores a soft-deleted entity by its ID
+   *
+   * @param id - The ID of the entity to restore
+   * @returns Promise resolving to the restored entity
+   * @throws NotFoundException if the entity doesn't exist
+   */
+  async restore(id: number): Promise<TEntity> {
+    const result = await this.repository.restore(id);
 
     if (result.affected === 0) {
-      // This should rarely happen if findOne succeeded, but handle it just in case
-      this.logger.warn(
-        `Failed to delete ${this.getEntityName().toLowerCase()} with ID ${id} - no rows affected`,
-      );
+      this.logger.warn(`${this.getEntityName()} with ID ${id} not found`);
       throw new NotFoundException(
         `${this.getEntityName()} with ID ${id} not found`,
       );
     }
 
+    const entity = await this.repository.findOne({
+      where: { id } as FindOptionsWhere<TEntity>,
+    });
+
     this.logger.log(
-      `Deleted ${this.getEntityName().toLowerCase()} with ID ${id}`,
+      `Restored ${this.getEntityName().toLowerCase()} with ID ${id}`,
     );
-    return DeleteResponseDto.withMessage(
-      `${this.getEntityName()} successfully deleted`,
-    );
+    return entity;
   }
 }

--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -424,14 +424,14 @@ describe('ProjectsService', () => {
         .spyOn(repository, 'findOne')
         .mockResolvedValue(existingProject as any);
       jest
-        .spyOn(repository, 'delete')
-        .mockResolvedValue({ affected: 1 } as any);
+        .spyOn(repository, 'softRemove')
+        .mockResolvedValue(existingProject as any);
 
       const result = await service.remove(1);
 
       expect(result).toBeInstanceOf(SuccessResponseDto);
       expect(result.data.message).toBe('Project successfully deleted');
-      expect(logSpy).toHaveBeenCalledWith(`Deleted project with ID 1`);
+      expect(logSpy).toHaveBeenCalledWith(`Soft-deleted project with ID 1`);
     });
 
     it('should invalidate cache after removing a project', async () => {
@@ -441,8 +441,8 @@ describe('ProjectsService', () => {
         .spyOn(repository, 'findOne')
         .mockResolvedValue(existingProject as any);
       jest
-        .spyOn(repository, 'delete')
-        .mockResolvedValue({ affected: 1 } as any);
+        .spyOn(repository, 'softRemove')
+        .mockResolvedValue(existingProject as any);
 
       await service.remove(1);
 
@@ -453,39 +453,16 @@ describe('ProjectsService', () => {
 
     it('should throw NotFoundException if project not found during initial check', async () => {
       jest.spyOn(repository, 'findOne').mockResolvedValue(undefined);
-      const deleteSpy = jest.spyOn(repository, 'delete');
+      const softRemoveSpy = jest.spyOn(repository, 'softRemove');
 
       await expect(service.remove(1)).rejects.toThrow(
         `Project with ID 1 not found`,
       );
       expect(warnSpy).toHaveBeenCalledWith(`Project with ID 1 not found`);
-      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(softRemoveSpy).not.toHaveBeenCalled();
     });
 
-    it('should throw NotFoundException if delete operation fails (no rows affected)', async () => {
-      const existingProject = {
-        id: 1,
-        title: 'Test Project',
-        description: 'Test Description',
-      };
-
-      jest
-        .spyOn(repository, 'findOne')
-        .mockResolvedValue(existingProject as any);
-      jest
-        .spyOn(repository, 'delete')
-        .mockResolvedValue({ affected: 0 } as any);
-
-      // If no rows affected, treat as not found
-      await expect(service.remove(1)).rejects.toThrow(
-        'Project with ID 1 not found',
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        `Failed to delete project with ID 1 - no rows affected`,
-      );
-    });
-
-    it('should let errors bubble up when repository.delete throws an error', async () => {
+    it('should let errors bubble up when repository.softRemove throws an error', async () => {
       const existingProject = {
         id: 1,
         title: 'Test Project',
@@ -497,7 +474,7 @@ describe('ProjectsService', () => {
       jest
         .spyOn(repository, 'findOne')
         .mockResolvedValue(existingProject as any);
-      jest.spyOn(repository, 'delete').mockRejectedValue(error);
+      jest.spyOn(repository, 'softRemove').mockRejectedValue(error);
 
       // Errors should bubble up naturally - let global exception filter handle them
       await expect(service.remove(1)).rejects.toThrow(error);


### PR DESCRIPTION
## Summary

- `BaseCrudService.remove()` now uses `softRemove()` instead of `delete()` — sets `deletedAt` timestamp
- Added `BaseCrudService.restore()` method for recovering soft-deleted entities
- TypeORM automatically excludes soft-deleted records from `find()` and `findOne()` queries (via `@DeleteDateColumn`)
- Tests updated for all services (projects, contacts)

Closes #53

## Test plan

- [ ] `DELETE /api/v1/projects/:id` sets `deletedAt` instead of removing row
- [ ] `GET /api/v1/projects` excludes soft-deleted records
- [ ] Soft-deleted records still exist in DB with `deletedAt` timestamp