### PR TITLE
fix(config): load all migrations in production

### DIFF
--- a/src/config/typeorm.config.prod.ts
+++ b/src/config/typeorm.config.prod.ts
@@ -10,7 +10,7 @@ const db = loadDatabaseConfig();
 export default new DataSource({
   ...(createTypeOrmOptions(db) as DataSourceOptions),
   entities: [__dirname + '/../**/*.entity.js'],
-  migrations: [__dirname + '/../database/migrations/*-migration.js'],
+  migrations: [__dirname + '/../database/migrations/*.js'],
   migrationsRun: false,
   logging: true,
 } as DataSourceOptions);


### PR DESCRIPTION
## Summary

Fix TypeORM migration loading in production to include all migration files.

## Problem

The production TypeORM config was only loading migrations matching `*-migration.js` pattern, which excluded the `HashApiKeys1774000000000` migration file.

## Solution

Changed the migration pattern from `*-migration.js` to `*.js` to load all migration files in the migrations directory.

## Impact

- Enables the `HashApiKeys` migration to run in production
- Fixes the `hashedKey` column missing error in API key creation

## Testing

After merge and deploy:
```bash
docker compose -f compose.prod.yml exec api yarn migration:run:prod
```