### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-03-19
+
+### Fixed
+
+- **TypeORM migration loading in production**: Changed migration pattern from `*-migration.js` to `*.js` to ensure all migration files are loaded, fixing the missing `HashApiKeys` migration that renames `api_keys.key` to `api_keys.hashedKey`
+
 ## [2.2.0] - 2026-03-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "author": "",
   "private": true,

--- a/src/config/typeorm.config.prod.ts
+++ b/src/config/typeorm.config.prod.ts
@@ -10,7 +10,7 @@ const db = loadDatabaseConfig();
 export default new DataSource({
   ...(createTypeOrmOptions(db) as DataSourceOptions),
   entities: [__dirname + '/../**/*.entity.js'],
-  migrations: [__dirname + '/../database/migrations/*-migration.js'],
+  migrations: [__dirname + '/../database/migrations/*.js'],
   migrationsRun: false,
   logging: true,
 } as DataSourceOptions);


### PR DESCRIPTION
## Release v2.2.1

### Fixed

- **TypeORM migration loading in production**: Changed migration pattern from `*-migration.js` to `*.js` to ensure all migration files are loaded

### Checklist

- [ ] Version bumped in package.json
- [ ] CHANGELOG.md updated
- [ ] Tests passing (if applicable)

## Post-merge actions

After merging to main:
1. Create release tag on GitHub
2. Merge main back into develop
3. Deploy to production
4. Run migrations: `docker compose -f compose.prod.yml exec api yarn migration:run:prod`