### PR TITLE
fix(seeder): remove tsconfig-paths from seed:test:prod script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "migration:run:prod": "node ./node_modules/typeorm/cli.js migration:run -d ./dist/src/config/typeorm.config.prod.js",
     "migration:revert:prod": "node ./node_modules/typeorm/cli.js migration:revert -d ./dist/src/config/typeorm.config.prod.js",
     "seed:test": "npx ts-node -r tsconfig-paths/register src/database/seeder.ts",
-    "seed:test:prod": "TS_NODE_PROJECT=./tsconfig.prod.json node -r tsconfig-paths/register dist/src/database/seeder.prod.js"
+    "seed:test:prod": "node dist/src/database/seeder.prod.js"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.0",


### PR DESCRIPTION
## Summary

Fix `seed:test:prod` script to run without `tsconfig-paths` module.

## Problem

The script was using `-r tsconfig-paths/register` but this module is a devDependency and is not installed in production containers.

## Solution

Removed the `tsconfig-paths/register` require flag. The compiled JavaScript already has path aliases resolved by TypeScript during build.

## Testing

After merge and deploy:
```bash
docker compose -f compose.prod.yml exec api yarn seed:test:prod
```