### PR TITLE
Release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-03-19
+
+### Fixed
+
+- **Production seeder script**: Removed `tsconfig-paths/register` from `seed:test:prod` script since it's a devDependency and path aliases are already resolved in compiled JavaScript
+
 ## [2.2.1] - 2026-03-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "",
   "author": "",
   "private": true,


### PR DESCRIPTION
## Release v2.2.2

### Fixed

- **Production seeder script**: Removed `tsconfig-paths/register` from `seed:test:prod` script

### Checklist

- [ ] Version bumped in package.json
- [ ] CHANGELOG.md updated
- [ ] Tests passing (if applicable)

## Post-merge actions

After merging to main:
1. Create release tag on GitHub
2. Merge main back into develop
3. Deploy to production
4. Run seeders (optional): `docker compose -f compose.prod.yml exec api yarn seed:test:prod`