### PR TITLE
chore(format): fix prettier drift on develop

### DIFF
--- a/src/config/mail.config.ts
+++ b/src/config/mail.config.ts
@@ -12,13 +12,16 @@ export interface MailConfig {
   to: string;
 }
 
-export default registerAs('mail', (): MailConfig => ({
-  enabled: process.env.MAIL_ENABLED === 'true',
-  host: trimEnvQuotes(process.env.MAIL_HOST) || 'localhost',
-  port: parseInt(trimEnvQuotes(process.env.MAIL_PORT) || '587', 10),
-  secure: trimEnvQuotes(process.env.MAIL_SECURE) === 'true',
-  user: trimEnvQuotes(process.env.MAIL_USER) || '',
-  password: trimEnvQuotes(process.env.MAIL_PASSWORD) || '',
-  from: trimEnvQuotes(process.env.MAIL_FROM) || 'portfolio@cativo.dev',
-  to: trimEnvQuotes(process.env.MAIL_TO) || 'cativo@cativo.dev',
-}));
+export default registerAs(
+  'mail',
+  (): MailConfig => ({
+    enabled: process.env.MAIL_ENABLED === 'true',
+    host: trimEnvQuotes(process.env.MAIL_HOST) || 'localhost',
+    port: parseInt(trimEnvQuotes(process.env.MAIL_PORT) || '587', 10),
+    secure: trimEnvQuotes(process.env.MAIL_SECURE) === 'true',
+    user: trimEnvQuotes(process.env.MAIL_USER) || '',
+    password: trimEnvQuotes(process.env.MAIL_PASSWORD) || '',
+    from: trimEnvQuotes(process.env.MAIL_FROM) || 'portfolio@cativo.dev',
+    to: trimEnvQuotes(process.env.MAIL_TO) || 'cativo@cativo.dev',
+  }),
+);

--- a/src/contacts/dto/create-contact.dto.ts
+++ b/src/contacts/dto/create-contact.dto.ts
@@ -1,4 +1,8 @@
-import { ApiProperty, ApiPropertyOptional, ApiHideProperty } from '@nestjs/swagger';
+import {
+  ApiProperty,
+  ApiPropertyOptional,
+  ApiHideProperty,
+} from '@nestjs/swagger';
 import {
   IsNotEmpty,
   IsOptional,

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -99,10 +99,14 @@ export class EmailService implements OnModuleInit {
       <div class="value"><a href="mailto:${this.escapeHtml(email)}" style="color: #7dcfff;">${this.escapeHtml(email)}</a></div>
     </div>
 
-    ${subject ? `<div class="field">
+    ${
+      subject
+        ? `<div class="field">
       <div class="label">Subject</div>
       <div class="value">${this.escapeHtml(subject)}</div>
-    </div>` : ''}
+    </div>`
+        : ''
+    }
 
     <div class="field">
       <div class="label">Message</div>

--- a/src/profile/dto/profile-response.dto.ts
+++ b/src/profile/dto/profile-response.dto.ts
@@ -18,7 +18,10 @@ export class ProfileSkillDto {
   @ApiProperty({ example: 'TypeScript' })
   name: string;
 
-  @ApiProperty({ example: 'advanced', enum: ['advanced', 'intermediate', 'basic'] })
+  @ApiProperty({
+    example: 'advanced',
+    enum: ['advanced', 'intermediate', 'basic'],
+  })
   level: string;
 }
 
@@ -43,7 +46,10 @@ export class ProfileResponseDto {
   @ApiProperty({ example: 'San Salvador, El Salvador' })
   location: string;
 
-  @ApiProperty({ example: 'Remote Tech Lead and Full-Stack Software Engineer with 9 years of experience building healthcare platforms, payment systems, and AI-powered products.' })
+  @ApiProperty({
+    example:
+      'Remote Tech Lead and Full-Stack Software Engineer with 9 years of experience building healthcare platforms, payment systems, and AI-powered products.',
+  })
   summary: string;
 
   @ApiProperty({ type: [ProfileExperienceDto] })

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -13,7 +13,8 @@ export class ProfileController {
   @Public()
   @ApiOperation({
     summary: 'Get professional profile information',
-    description: 'Returns Carlos Cativo\'s professional profile including experience, skills, and differentiators.',
+    description:
+      "Returns Carlos Cativo's professional profile including experience, skills, and differentiators.",
   })
   @ApiResponse({
     status: 200,

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -15,6 +15,8 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   @MinLength(6)
-  @ApiPropertyOptional({ description: 'New password (leave blank to keep current)' })
+  @ApiPropertyOptional({
+    description: 'New password (leave blank to keep current)',
+  })
   password?: string;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,7 +11,13 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiParam, ApiBody } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { UsersService } from '@users/users.service';
 import { AuthGuard } from '@auth/auth.guard';
 import { UserResponseDto } from '@users/dto/user-response.dto';
@@ -35,7 +41,9 @@ export class UsersController {
   @Get(':id')
   @ApiOperation({ summary: 'Get a user by ID' })
   @ApiParam({ name: 'id', type: Number, description: 'User ID' })
-  async findOne(@Param('id', ParseIntPipe) id: number): Promise<UserResponseDto> {
+  async findOne(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<UserResponseDto> {
     const user = await this.usersService.findOne(id);
     return UserResponseDto.fromEntity(user);
   }
@@ -64,7 +72,9 @@ export class UsersController {
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a user by ID' })
   @ApiParam({ name: 'id', type: Number, description: 'User ID' })
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<{ deleted: number }> {
+  async remove(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<{ deleted: number }> {
     await this.usersService.remove(id);
     return { deleted: id };
   }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -100,8 +100,18 @@ describe('UsersService', () => {
   describe('findAll', () => {
     it('should return all users ordered by createdAt DESC', async () => {
       const users: User[] = [
-        { id: 1, username: 'user1', email: 'a@b.com', password: 'hash' } as User,
-        { id: 2, username: 'user2', email: 'c@d.com', password: 'hash' } as User,
+        {
+          id: 1,
+          username: 'user1',
+          email: 'a@b.com',
+          password: 'hash',
+        } as User,
+        {
+          id: 2,
+          username: 'user2',
+          email: 'c@d.com',
+          password: 'hash',
+        } as User,
       ];
 
       jest.spyOn(repository, 'find').mockResolvedValue(users);
@@ -178,9 +188,9 @@ describe('UsersService', () => {
       const updateDto: UpdateUserDto = { password: 'NewStr0ng!Pass' };
 
       jest.spyOn(repository, 'findOneBy').mockResolvedValue(existingUser);
-      jest.spyOn(repository, 'save').mockImplementation((user) =>
-        Promise.resolve(user as User),
-      );
+      jest
+        .spyOn(repository, 'save')
+        .mockImplementation((user) => Promise.resolve(user as User));
 
       const result = await service.update(1, updateDto);
 


### PR DESCRIPTION
## Summary

CI on develop has been failing since #104/#108 because 8 files drifted from Prettier formatting. This PR runs \`yarn format\` to clean them up — no behavior changes, only whitespace.

Files affected:
- \`src/config/mail.config.ts\`
- \`src/contacts/dto/create-contact.dto.ts\`
- \`src/email/email.service.ts\`
- \`src/profile/dto/profile-response.dto.ts\`
- \`src/profile/profile.controller.ts\`
- \`src/users/dto/update-user.dto.ts\`
- \`src/users/users.controller.ts\`
- \`src/users/users.service.spec.ts\`

## Test plan
- [x] \`yarn format:check\` — All matched files use Prettier code style!
- [x] \`yarn jest\` — full suite passes
- [x] No code logic changes (only multi-line wraps of long imports and signatures)