### PR TITLE
fix(contacts): repair contacts.service.spec (EmailService DI + log assertion)

### DIFF
--- a/src/contacts/contacts.service.spec.ts
+++ b/src/contacts/contacts.service.spec.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import { Contact } from './entities/contact.entity';
 import { CreateContactDto } from './dto/create-contact.dto';
 import { Logger } from '@nestjs/common';
+import { EmailService } from '@email/email.service';
 
 describe('ContactsService', () => {
   let service: ContactsService;
@@ -24,6 +25,12 @@ describe('ContactsService', () => {
         {
           provide: getRepositoryToken(Contact),
           useClass: Repository,
+        },
+        {
+          provide: EmailService,
+          useValue: {
+            sendNewContactNotification: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();
@@ -64,7 +71,7 @@ describe('ContactsService', () => {
         }),
       );
       expect(logSpy).toHaveBeenCalledWith(
-        `Contact created with ID ${contact.id}`,
+        `Created new contact: ${contact.name}`,
       );
     });
 


### PR DESCRIPTION
## Summary

Fixes 12/12 failing tests in `src/contacts/contacts.service.spec.ts` introduced by the merge of #104. The CI pipeline was masking this because the format check failed first — once #109 fixes formatting, the test failures surface.

1. \`ContactsService\` gained an \`EmailService\` dependency for new-contact email notifications. The spec's \`TestingModule\` didn't provide it → every test failed with \`Nest can't resolve dependencies of the ContactsService (ContactRepository, ?)\`.
2. The success log message in \`create()\` was renamed from \`Contact created with ID N\` to \`Created new contact: <name>\` but the spec assertion still expected the old format.

## Changes

- Add \`EmailService\` mock to test module providers with a stub \`sendNewContactNotification\` that resolves \`undefined\`.
- Realign the success log assertion to match the current service implementation.

## Test plan

- [x] \`yarn jest src/contacts/contacts.service.spec.ts\` — 12/12 ✓
- [x] \`yarn jest\` — full suite **415/415** ✓