### PR TITLE
fix(deploy): replace hardcoded SSH host/port with repo vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,10 +60,10 @@ jobs:
       - name: Copy compose file to server
         uses: appleboy/scp-action@v1
         with:
-          host: 186.32.90.71
+          host: ${{ vars.DEPLOY_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: 52222
+          port: ${{ vars.DEPLOY_PORT }}
           source: "compose.prod.yml"
           target: "/home/cativo23/deploy/portfolio-api-deploy"
           debug: true
@@ -75,10 +75,10 @@ jobs:
       - name: Deploy to server
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: 186.32.90.71
+          host: ${{ vars.DEPLOY_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: 52222
+          port: ${{ vars.DEPLOY_PORT }}
           envs: DOCKER_USERNAME,DB_USERNAME,DB_PASSWORD,DB_NAME,MYSQL_ROOT_PASSWORD,JWT_SECRET,JWT_EXPIRES_IN,CORS_ORIGINS,API_KEY_SECRET,REDIS_PASSWORD,REDIS_TTL,THROTTLE_TTL,THROTTLE_LIMIT,THROTTLE_PUBLIC_LIMIT,THROTTLE_STRICT_LIMIT
           script: |
             # Docker and database credentials


### PR DESCRIPTION
## Summary

The deploy workflow was failing with timeout on \`scp\` because \`host: 186.32.90.71\` was the **old laptop IP** before the Hetzner migration. v2.6.0's deploy job timed out for this reason.

## Changes

- \`scp-action\` and \`ssh-action\` steps now use \`\${{ vars.DEPLOY_HOST }}\` and \`\${{ vars.DEPLOY_PORT }}\`
- Repo vars set: \`DEPLOY_HOST=167.235.52.161\` (polaris2), \`DEPLOY_PORT=52222\`

## Why a hotfix to main directly

Workflow files in \`main\` only take effect for events triggered against \`main\`. Going through develop → release would defer the fix. v2.6.0 was already deployed manually (image pulled + containers up + migrations applied on polaris2) so this PR only fixes the automation for v2.6.1 onwards.

## Test plan

- [x] \`yarn lint\` clean
- [x] Verified \`vars.DEPLOY_HOST\` and \`vars.DEPLOY_PORT\` are populated in repo settings
- [ ] Next release will exercise the path