### PR TITLE
fix(auth): extract expires_at from JWT exp claim (#97)

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -13,7 +13,6 @@ describe('AuthService', () => {
   let service: AuthService;
   let usersService: Mocked<UsersService>;
   let jwtService: Mocked<JwtService>;
-  let configService: Mocked<ConfigService>;
 
   const password = '123456';
   let hashedPassword: string;
@@ -30,6 +29,7 @@ describe('AuthService', () => {
 
     const mockJwtService = {
       signAsync: vi.fn(),
+      decode: vi.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -58,7 +58,6 @@ describe('AuthService', () => {
     service = module.get<AuthService>(AuthService);
     usersService = module.get(UsersService) as Mocked<UsersService>;
     jwtService = module.get(JwtService) as Mocked<JwtService>;
-    configService = module.get(ConfigService) as Mocked<ConfigService>;
   });
 
   it('should be defined', () => {
@@ -167,15 +166,17 @@ describe('AuthService', () => {
         password: hashedPassword,
       } as User;
 
+      const decodedExp = Math.floor((fixedNow + 3600 * 1000) / 1000);
+
       usersService.findOneByEmail.mockResolvedValue(user);
       jwtService.signAsync.mockResolvedValue('fake-jwt-token');
-      configService.getOrThrow.mockReturnValue(3600); // 1 hour
+      jwtService.decode.mockReturnValue({ exp: decodedExp });
 
       const result = await service.login(user.email, password);
 
       expect(result).toEqual({
         access_token: 'fake-jwt-token',
-        expires_at: new Date(fixedNow + 3600 * 1000),
+        expires_at: new Date(decodedExp * 1000),
         user: {
           id: user.id,
           username: user.username,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,9 +1,9 @@
 import { vi, type Mocked } from 'vitest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UsersService } from '@users/users.service';
 import { JwtService } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
 import { RegisterDto } from './dto/register.dto';
 import { User } from '@users/entities/user.entity';
@@ -37,21 +37,6 @@ describe('AuthService', () => {
         AuthService,
         { provide: UsersService, useValue: mockUsersService },
         { provide: JwtService, useValue: mockJwtService },
-        {
-          provide: ConfigService,
-          useValue: {
-            get: vi.fn(),
-            getOrThrow: vi.fn().mockImplementation((key: string) => {
-              const config: Record<string, string | number> = {
-                JWT_SECRET: 'test-secret',
-                JWT_EXPIRES_IN: 3600,
-              };
-              if (!(key in config))
-                throw new Error(`Config key ${key} not found`);
-              return config[key];
-            }),
-          },
-        },
       ],
     }).compile();
 
@@ -174,6 +159,7 @@ describe('AuthService', () => {
 
       const result = await service.login(user.email, password);
 
+      expect(jwtService.decode).toHaveBeenCalledWith('fake-jwt-token');
       expect(result).toEqual({
         access_token: 'fake-jwt-token',
         expires_at: new Date(decodedExp * 1000),
@@ -183,6 +169,23 @@ describe('AuthService', () => {
           email: user.email,
         },
       });
+    });
+
+    it('should throw InternalServerErrorException when JWT has no exp claim', async () => {
+      const user = {
+        id: 1,
+        email: 'test@mail.com',
+        username: 'test',
+        password: hashedPassword,
+      } as User;
+
+      usersService.findOneByEmail.mockResolvedValue(user);
+      jwtService.signAsync.mockResolvedValue('fake-jwt-token');
+      jwtService.decode.mockReturnValue(null);
+
+      await expect(service.login(user.email, password)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
 
     it('should throw if credentials are invalid', async () => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,9 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '@users/users.service';
 import { RegisterDto } from '@auth/dto/register.dto';
-import { ConfigService } from '@nestjs/config';
 import { User } from '@users/entities/user.entity';
 import { ConflictException, AuthenticationException } from '@core/exceptions';
 
@@ -17,7 +16,6 @@ export class AuthService {
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
-    private configService: ConfigService,
   ) {}
 
   /**
@@ -64,12 +62,21 @@ export class AuthService {
     const payload = { sub: user.id, email: user.email, roles: user.roles };
 
     const access_token = await this.jwtService.signAsync(payload);
-    const decoded = this.jwtService.decode(access_token) as { exp: number };
+    const decoded = this.jwtService.decode(access_token);
 
-    // Return token, its actual expiration derived from the JWT exp claim, and user info
+    if (
+      !decoded ||
+      typeof decoded === 'string' ||
+      typeof decoded['exp'] !== 'number'
+    ) {
+      throw new InternalServerErrorException(
+        'JWT issued without exp claim — check JWT_EXPIRES_IN configuration',
+      );
+    }
+
     return {
       access_token,
-      expires_at: new Date(decoded.exp * 1000),
+      expires_at: new Date(decoded['exp'] * 1000),
       user: {
         id: user.id,
         username: user.username,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -64,14 +64,12 @@ export class AuthService {
     const payload = { sub: user.id, email: user.email, roles: user.roles };
 
     const access_token = await this.jwtService.signAsync(payload);
+    const decoded = this.jwtService.decode(access_token) as { exp: number };
 
-    // Return token, until when its valid the toke and user info
+    // Return token, its actual expiration derived from the JWT exp claim, and user info
     return {
-      access_token: access_token,
-      expires_at: new Date(
-        Date.now() +
-          this.configService.getOrThrow<number>('JWT_EXPIRES_IN') * 1000,
-      ),
+      access_token,
+      expires_at: new Date(decoded.exp * 1000),
       user: {
         id: user.id,
         username: user.username,


### PR DESCRIPTION
## Summary

- Replaces the manual `Date.now() + JWT_EXPIRES_IN * 1000` calculation with `jwtService.decode(access_token).exp` so `expires_at` in the login response matches the token's actual expiration — eliminates clock-skew between the manual offset and the JWT's own `iat`/`exp` stamps
- Adds runtime guard: throws `InternalServerErrorException` if `decode()` returns null, a string, or an object without a numeric `exp` — prevents silent `Invalid Date` or `TypeError` if JWT configuration is broken
- Removes the now-unused `ConfigService` injection from `AuthService` (only used for the manual offset)
- Closes #97

## Changes

| File | Change |
|---|---|
| `src/auth/auth.service.ts` | Use `jwtService.decode()`, add guard, remove `ConfigService` |
| `src/auth/auth.service.spec.ts` | Drop dead `ConfigService` mock, assert `decode` called with signed token, add null-decode test |

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test src/auth/auth.service.spec.ts` — 9 tests pass (includes new null-exp guard test)
- [x] `yarn test` — 502 tests pass
- [x] `yarn lint` — clean