### PR TITLE
fix(cors): restrict dev origins to explicit allowlist (#98)

### DIFF
--- a/src/config/cors.utils.spec.ts
+++ b/src/config/cors.utils.spec.ts
@@ -1,0 +1,63 @@
+import { buildCorsAllowlist, isOriginAllowed } from './cors.utils';
+import type { AppConfig } from './configuration.types';
+
+function makeConfig(nodeEnv: string, corsOrigins: string[] = []): AppConfig {
+  return { nodeEnv, corsOrigins, port: 3000 };
+}
+
+describe('buildCorsAllowlist', () => {
+  it('returns only configured origins in production', () => {
+    const cfg = makeConfig('production', ['https://mysite.com']);
+    expect(buildCorsAllowlist(cfg)).toEqual(['https://mysite.com']);
+  });
+
+  it('appends localhost dev-server ports in development', () => {
+    const cfg = makeConfig('development', ['https://mysite.com']);
+    const list = buildCorsAllowlist(cfg);
+    expect(list).toContain('https://mysite.com');
+    expect(list).toContain('http://localhost:3000');
+    expect(list).toContain('http://localhost:4200');
+    expect(list).toContain('http://localhost:5173');
+    expect(list).toContain('http://localhost:5174');
+    expect(list).toContain('http://localhost:8080');
+  });
+
+  it('deduplicates when configured origin overlaps with a dev port', () => {
+    const cfg = makeConfig('development', ['http://localhost:3000']);
+    const list = buildCorsAllowlist(cfg);
+    expect(list.filter((o) => o === 'http://localhost:3000')).toHaveLength(1);
+  });
+
+  it('returns empty list in production when no origins are configured', () => {
+    const cfg = makeConfig('production', []);
+    expect(buildCorsAllowlist(cfg)).toEqual([]);
+  });
+
+  it('does not add localhost ports in test or staging environments', () => {
+    const cfg = makeConfig('test', ['https://staging.mysite.com']);
+    const list = buildCorsAllowlist(cfg);
+    expect(list).toEqual(['https://staging.mysite.com']);
+    expect(list).not.toContain('http://localhost:3000');
+  });
+});
+
+describe('isOriginAllowed', () => {
+  const allowlist = ['https://mysite.com', 'https://admin.mysite.com'];
+
+  it('returns true for a listed origin', () => {
+    expect(isOriginAllowed('https://mysite.com', allowlist)).toBe(true);
+  });
+
+  it('returns false for an unlisted origin', () => {
+    expect(isOriginAllowed('https://evil.com', allowlist)).toBe(false);
+  });
+
+  it('returns true when origin is undefined (non-browser / curl calls)', () => {
+    expect(isOriginAllowed(undefined, allowlist)).toBe(true);
+  });
+
+  it('is case-sensitive and does not match trailing slashes', () => {
+    expect(isOriginAllowed('https://mysite.com/', allowlist)).toBe(false);
+    expect(isOriginAllowed('HTTPS://mysite.com', allowlist)).toBe(false);
+  });
+});

--- a/src/config/cors.utils.ts
+++ b/src/config/cors.utils.ts
@@ -1,0 +1,39 @@
+import type { AppConfig } from '@config/configuration.types';
+
+const DEV_LOCALHOST_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:3001',
+  'http://localhost:4173',
+  'http://localhost:4200',
+  'http://localhost:5173',
+  'http://localhost:5174',
+  'http://localhost:8080',
+];
+
+/**
+ * Builds the CORS allowlist for the current environment.
+ * In development, common localhost dev-server ports are appended.
+ * In all other environments, only the configured origins are used.
+ */
+export function buildCorsAllowlist(appConfig: AppConfig): string[] {
+  if (appConfig.nodeEnv === 'development') {
+    const combined = new Set([
+      ...appConfig.corsOrigins,
+      ...DEV_LOCALHOST_ORIGINS,
+    ]);
+    return Array.from(combined);
+  }
+  return appConfig.corsOrigins;
+}
+
+/**
+ * Returns true if the request origin should be allowed.
+ * Blank origin (no Origin header) is allowed for non-browser callers.
+ */
+export function isOriginAllowed(
+  origin: string | undefined,
+  allowlist: string[],
+): boolean {
+  if (!origin) return true;
+  return allowlist.includes(origin);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,14 +35,23 @@ async function bootstrap() {
       origin: string | undefined,
       callback: (err: Error | null, allow?: boolean) => void,
     ) => {
+      // Allow server-to-server requests with no Origin header (curl, internal services)
       if (!origin) {
         return callback(null, true);
       }
 
-      if (
-        appConfig.corsOrigins.includes(origin) ||
+      const allowedOrigins =
         appConfig.nodeEnv === 'development'
-      ) {
+          ? [
+              ...appConfig.corsOrigins,
+              'http://localhost',
+              'http://localhost:3000',
+              'http://localhost:4200',
+              'http://localhost:5173',
+            ]
+          : appConfig.corsOrigins;
+
+      if (allowedOrigins.includes(origin)) {
         callback(null, true);
       } else {
         callback(new Error('Not allowed by CORS'));

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from '@nestjs/common';
 import { ValidationPipe } from '@core';
 import { loadAppConfig } from '@config/configuration.loaders';
+import { buildCorsAllowlist, isOriginAllowed } from '@config/cors.utils';
 import { ClsMiddleware } from 'nestjs-cls';
 import helmet from 'helmet';
 
@@ -30,34 +31,20 @@ async function bootstrap() {
     }),
   );
 
+  const corsAllowlist = buildCorsAllowlist(appConfig);
+
   app.enableCors({
     origin: (
       origin: string | undefined,
       callback: (err: Error | null, allow?: boolean) => void,
     ) => {
-      // Allow server-to-server requests with no Origin header (curl, internal services)
-      if (!origin) {
-        return callback(null, true);
-      }
-
-      const allowedOrigins =
-        appConfig.nodeEnv === 'development'
-          ? [
-              ...appConfig.corsOrigins,
-              'http://localhost',
-              'http://localhost:3000',
-              'http://localhost:4200',
-              'http://localhost:5173',
-            ]
-          : appConfig.corsOrigins;
-
-      if (allowedOrigins.includes(origin)) {
+      if (isOriginAllowed(origin, corsAllowlist)) {
         callback(null, true);
       } else {
-        callback(new Error('Not allowed by CORS'));
+        Logger.warn(`CORS blocked origin: ${origin}`, 'Bootstrap');
+        callback(null, false);
       }
     },
-    credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
     exposedHeaders: ['Content-Range', 'X-Content-Range'],


### PR DESCRIPTION
## Summary

- Removes wildcard dev CORS (`nodeEnv === 'development'` → allow all) and replaces it with an explicit allowlist of common dev-server ports
- Extracts origin-decision logic to a pure, unit-tested helper (`src/config/cors.utils.ts`) — single source of truth, no more drift between `main.ts` and `configuration.loaders.ts`
- Removes `credentials: true` — API uses Bearer JWT + `x-api-key`; cookies not in use, so this was granting unnecessary CORS credential sharing
- Fixes `callback(new Error(...))` → `callback(null, false)` — standard CORS deny, avoids routing through the error handler
- Logs rejected origins at `warn` level for production debugging
- Closes #98

## Changes

| File | Change |
|---|---|
| `src/config/cors.utils.ts` | New — `buildCorsAllowlist()` + `isOriginAllowed()` |
| `src/config/cors.utils.spec.ts` | New — 9 unit tests |
| `src/main.ts` | Use helpers, remove `credentials: true`, fix deny callback, add warn log |

## Dev allowlist ports
`3000, 3001, 4173, 4200, 5173, 5174, 8080` (covers CRA, Next, Vite, Vite-preview, Angular, Webpack)

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test src/config/cors.utils.spec.ts` — 9 tests pass
- [x] `yarn test` — 511 tests pass
- [x] `yarn lint` — clean