### PR TITLE
fix(projects): add explicit varchar type to liveUrl column

### DIFF
--- a/src/projects/entities/project.entity.ts
+++ b/src/projects/entities/project.entity.ts
@@ -15,7 +15,7 @@ export class Project extends BaseEntity {
   @Column()
   shortDescription: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   liveUrl: string | null;
 
   @Column()


### PR DESCRIPTION
## Summary
- Adds `type: 'varchar'` to `Project.liveUrl` `@Column` decorator
- Fixes production crash: `DataTypeNotSupportedError: Data type "Object" in "Project.liveUrl" is not supported by "mysql" database`

## Root Cause
TypeORM uses `reflect-metadata` to infer SQL column types from TypeScript property types. When we changed `liveUrl: string` → `liveUrl: string | null` (strict-mode fix #95), the reflected JS type became `Object` instead of `String`. TypeORM couldn't map `Object` to a MySQL column type.

## Fix
Added explicit `type: 'varchar'` to the `@Column` decorator. No migration needed — the SQL schema is unchanged.

## Test plan
- [x] All 85 project tests pass
- [x] TypeORM entity validation resolves correctly with explicit type