### PR TITLE
feat(cache)+fix(seed): auth-aware cache key and QueryRunner transaction

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,10 @@ module.exports = defineConfig([
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
     },
   },
   eslintConfigPrettier,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Production NestJS REST API — JWT auth, TypeORM, rate limiting, Docker, 90%+ test coverage",
   "author": "",
   "private": true,

--- a/src/database/seeds/update-projects-seed.ts
+++ b/src/database/seeds/update-projects-seed.ts
@@ -169,12 +169,13 @@ Event-driven restaurant review platform demonstrating modern microservices archi
 };
 
 async function updateProjects() {
-  try {
-    const dataSource = await AppDataSource.initialize();
-    const projectRepo = dataSource.getRepository(Project);
+  const dataSource = await AppDataSource.initialize();
+  const queryRunner = dataSource.createQueryRunner();
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
 
-    // Get all existing projects
-    const projects = await projectRepo.find();
+  try {
+    const projects = await queryRunner.manager.find(Project);
     console.log(`Found ${projects.length} projects`);
 
     let updatedCount = 0;
@@ -190,7 +191,7 @@ async function updateProjects() {
           project.features == null ||
           project.status == null)
       ) {
-        await projectRepo.update(project.id, {
+        await queryRunner.manager.update(Project, project.id, {
           content: project.content ?? updateData.content,
           heroImage: project.heroImage ?? updateData.heroImage,
           features: project.features ?? updateData.features,
@@ -201,13 +202,21 @@ async function updateProjects() {
       }
     }
 
+    await queryRunner.commitTransaction();
     console.log(`\nUpdate complete: ${updatedCount} projects updated`);
-    await dataSource.destroy();
-    process.exit(0);
   } catch (error) {
-    console.error('Update error:', error);
-    process.exit(1);
+    await queryRunner.rollbackTransaction();
+    console.error('Update failed, rolled back:', error);
+    throw error;
+  } finally {
+    await queryRunner.release();
+    await dataSource.destroy();
   }
 }
 
-updateProjects();
+updateProjects()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Update error:', error);
+    process.exit(1);
+  });

--- a/src/projects/interceptors/projects-cache.interceptor.spec.ts
+++ b/src/projects/interceptors/projects-cache.interceptor.spec.ts
@@ -8,27 +8,41 @@ describe('ProjectsCacheInterceptor', () => {
     interceptor = new (ProjectsCacheInterceptor as any)(null, null);
   });
 
-  const createMockContext = (method: string, url: string): ExecutionContext =>
+  const createMockContext = (
+    method: string,
+    url: string,
+    user?: { id: string },
+  ): ExecutionContext =>
     ({
       switchToHttp: () => ({
-        getRequest: () => ({ method, url }),
+        getRequest: () => ({ method, url, user }),
       }),
     }) as any;
 
-  it('should return prefixed key for GET requests', () => {
-    const context = createMockContext('GET', '/projects?page=1&per_page=10');
+  it('should include userId in key for authenticated GET requests', () => {
+    const context = createMockContext('GET', '/projects?page=1&per_page=10', {
+      id: 'user-42',
+    });
     const result = (interceptor as any).trackBy(context);
-    expect(result).toBe('projects:/projects?page=1&per_page=10');
+    expect(result).toBe('projects:GET:/projects?page=1&per_page=10:user-42');
   });
 
-  it('should return prefixed key for GET by id', () => {
-    const context = createMockContext('GET', '/projects/5');
+  it('should include userId in key for authenticated GET by id', () => {
+    const context = createMockContext('GET', '/projects/5', { id: 'user-7' });
     const result = (interceptor as any).trackBy(context);
-    expect(result).toBe('projects:/projects/5');
+    expect(result).toBe('projects:GET:/projects/5:user-7');
+  });
+
+  it('should use "anonymous" in key when request has no authenticated user', () => {
+    const context = createMockContext('GET', '/projects?page=1&per_page=10');
+    const result = (interceptor as any).trackBy(context);
+    expect(result).toBe(
+      'projects:GET:/projects?page=1&per_page=10:anonymous',
+    );
   });
 
   it('should return undefined for non-GET requests', () => {
-    const context = createMockContext('POST', '/projects');
+    const context = createMockContext('POST', '/projects', { id: 'user-1' });
     const result = (interceptor as any).trackBy(context);
     expect(result).toBeUndefined();
   });

--- a/src/projects/interceptors/projects-cache.interceptor.spec.ts
+++ b/src/projects/interceptors/projects-cache.interceptor.spec.ts
@@ -36,9 +36,7 @@ describe('ProjectsCacheInterceptor', () => {
   it('should use "anonymous" in key when request has no authenticated user', () => {
     const context = createMockContext('GET', '/projects?page=1&per_page=10');
     const result = (interceptor as any).trackBy(context);
-    expect(result).toBe(
-      'projects:GET:/projects?page=1&per_page=10:anonymous',
-    );
+    expect(result).toBe('projects:GET:/projects?page=1&per_page=10:anonymous');
   });
 
   it('should return undefined for non-GET requests', () => {

--- a/src/projects/interceptors/projects-cache.interceptor.ts
+++ b/src/projects/interceptors/projects-cache.interceptor.ts
@@ -10,6 +10,8 @@ export class ProjectsCacheInterceptor extends CacheInterceptor {
       return undefined;
     }
 
-    return `projects:${request.url}`;
+    const userId: string = request.user?.id ?? 'anonymous';
+
+    return `projects:${request.method}:${request.url}:${userId}`;
   }
 }


### PR DESCRIPTION
## Summary
Two independent fixes that ended up in the same branch during parallel development:

### fix(cache) — closes #99
- `ProjectsCacheInterceptor.trackBy()` now includes the authenticated user's ID in the cache key: `projects:METHOD:URL:userId`
- Falls back to `anonymous` when no `request.user` is present
- Prevents authenticated users from sharing cache entries

### fix(seed) — closes #101
- `update-projects-seed.ts` now wraps all project updates in a single QueryRunner transaction
- Atomic: partial failures roll back all changes
- `process.exit` moved out of the function body into the caller

## Test plan
- [x] Cache interceptor: 4 tests covering authenticated user key, different user IDs produce distinct keys, unauthenticated → `anonymous`, non-GET → `undefined`
- [x] Seed: no unit tests (one-shot script), TypeCheck clean