### PR TITLE
fix(contacts): replace never type with explicit MethodNotAllowedException override

### DIFF
--- a/src/contacts/contacts.service.spec.ts
+++ b/src/contacts/contacts.service.spec.ts
@@ -5,7 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Contact } from './entities/contact.entity';
 import { CreateContactDto } from './dto/create-contact.dto';
-import { Logger } from '@nestjs/common';
+import { Logger, MethodNotAllowedException } from '@nestjs/common';
 import { EmailService } from '@email/email.service';
 
 describe('ContactsService', () => {
@@ -88,6 +88,14 @@ describe('ContactsService', () => {
       const result = await service.create(createContactDto);
 
       expect(result).toEqual(expect.objectContaining({ id: contact.id }));
+    });
+  });
+
+  describe('update', () => {
+    it('should throw MethodNotAllowedException', async () => {
+      await expect(service.update(1, {})).rejects.toThrow(
+        MethodNotAllowedException,
+      );
     });
   });
 

--- a/src/contacts/contacts.service.ts
+++ b/src/contacts/contacts.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, MethodNotAllowedException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { Contact } from '@contacts/entities/contact.entity';
-import { CreateContactDto } from '@contacts/dto';
+import { CreateContactDto, UpdateContactDto } from '@contacts/dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PaginationUtil } from '@core/utils/pagination.util';
 import { BaseCrudService } from '@core/services/base-crud.service';
@@ -21,12 +21,6 @@ interface FindAllOptions {
   /** Optional flag to filter contacts by read status */
   isRead?: boolean | undefined;
 }
-
-/**
- * Placeholder type for UpdateContactDto
- * Contacts don't have a general update operation, only markAsRead
- */
-type UpdateContactDto = never;
 
 /**
  * Service responsible for managing contact form submissions
@@ -56,6 +50,12 @@ export class ContactsService extends BaseCrudService<
 
   protected getEntityName(): string {
     return 'Contact';
+  }
+
+  override async update(_id: number, _dto: UpdateContactDto): Promise<Contact> {
+    throw new MethodNotAllowedException(
+      'Contacts do not support direct updates. Use markAsRead instead.',
+    );
   }
 
   /**

--- a/src/contacts/dto/index.ts
+++ b/src/contacts/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './create-contact.dto';
+export * from './update-contact.dto';
 export * from './contact-response.dto';
 export * from './single-contact-response.dto';
 export * from './contacts-list-response.dto';

--- a/src/contacts/dto/update-contact.dto.ts
+++ b/src/contacts/dto/update-contact.dto.ts
@@ -1,0 +1,1 @@
+export class UpdateContactDto {}


### PR DESCRIPTION
## Summary

- Removes the `type UpdateContactDto = never` local type alias from `ContactsService` — using `never` as a generic parameter was a type-system abuse that silently made `update()` uncallable at compile-time with no runtime protection
- Creates `src/contacts/dto/update-contact.dto.ts` as a proper empty DTO class and exports it from the barrel
- Adds an explicit `override update()` method that throws `MethodNotAllowedException` with a clear message, documenting the immutability constraint at runtime
- Adds a `describe('update')` test that asserts the exception is thrown

Closes #100

## Test plan

- [x] `docker compose exec -T api yarn test --run src/contacts --no-coverage` — all 46 tests pass (13 in `contacts.service.spec.ts`)
- [x] New `update` describe block verifies `MethodNotAllowedException` is thrown