### PR TITLE
Sprint 0 security: hash passwords, redact query logs, fix roles

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -13,7 +13,7 @@ describe('AuthController', () => {
   let controller: AuthController;
   let authService: AuthService;
 
-  const mockUser: User = {
+  const mockUser = {
     id: 1,
     username: 'john_doe',
     email: 'john@example.com',
@@ -22,7 +22,7 @@ describe('AuthController', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     deletedAt: null,
-  };
+  } as User;
 
   const mockAuthService = {
     login: vi.fn(),
@@ -130,12 +130,12 @@ describe('AuthController', () => {
   describe('profile', () => {
     it('should return user from decorator', () => {
       const mockRequest = { user: mockUser };
-      const mockUserDecorator: User = {
+      const mockUserDecorator = {
         ...mockUser,
         id: 2,
         username: 'decorator',
         email: 'decorator@example.com',
-      };
+      } as User;
 
       const result = controller.profile(mockRequest as any, mockUserDecorator);
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -64,10 +64,13 @@ describe('AuthService', () => {
       const result = await service.register(payload);
 
       expect(usersService.findOneByEmail).toHaveBeenCalledWith(payload.email);
+      // register no longer pre-hashes — hashing is owned by UsersService.create,
+      // so it must forward the raw password (avoids double-hashing).
       expect(usersService.create).toHaveBeenCalledWith(
         expect.objectContaining({
           email: payload.email,
           username: payload.username,
+          password: payload.password,
         }),
       );
       expect(result).toMatchObject({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -31,12 +31,13 @@ export class AuthService {
     if (existingUser) {
       throw new ConflictException('Email already exists');
     }
-    const hashedPassword = await bcrypt.hash(payload.password, 10);
 
+    // Hashing is owned by UsersService.create() so every insert path hashes
+    // exactly once — forward the raw password here to avoid double-hashing.
     return await this.usersService.create({
       username: payload.username,
       email: payload.email,
-      password: hashedPassword,
+      password: payload.password,
     });
   }
 

--- a/src/config/typeorm.config.prod.ts
+++ b/src/config/typeorm.config.prod.ts
@@ -12,5 +12,6 @@ export default new DataSource({
   entities: [__dirname + '/../**/*.entity.js'],
   migrations: [__dirname + '/../database/migrations/*.js'],
   migrationsRun: false,
-  logging: true,
+  // Never log every query (with bound params) in prod — keep it to errors/warns.
+  logging: ['error', 'warn'],
 } as DataSourceOptions);

--- a/src/database/logger/typeorm-logger.service.spec.ts
+++ b/src/database/logger/typeorm-logger.service.spec.ts
@@ -33,6 +33,20 @@ describe('TypeOrmLoggerService', () => {
         service.logQuery('SELECT * FROM users WHERE id = ?', [1]),
       ).not.toThrow();
     });
+
+    it('never writes parameter values to the log', () => {
+      const logSpy = vi
+        .spyOn(Logger.prototype, 'log')
+        .mockImplementation(vi.fn());
+      const service = new TypeOrmLoggerService(createMockConfigService(['query']));
+
+      service.logQuery('INSERT INTO `user`(`password`) VALUES (?)', [
+        'SuperSecret123!',
+      ]);
+
+      expect(logSpy.mock.calls.flat().join(' ')).not.toContain('SuperSecret123!');
+      logSpy.mockRestore();
+    });
   });
 
   describe('logQueryError', () => {
@@ -105,6 +119,22 @@ describe('TypeOrmLoggerService', () => {
       expect(() =>
         service.logQuerySlow(5000, 'SELECT * FROM users'),
       ).not.toThrow();
+    });
+
+    it('never writes parameter values to the log', () => {
+      const warnSpy = vi
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(vi.fn());
+      const service = new TypeOrmLoggerService(createMockConfigService(['warn']));
+
+      service.logQuerySlow(5000, 'SELECT * FROM `user` WHERE email = ?', [
+        'victim@example.com',
+      ]);
+
+      expect(warnSpy.mock.calls.flat().join(' ')).not.toContain(
+        'victim@example.com',
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/database/logger/typeorm-logger.service.spec.ts
+++ b/src/database/logger/typeorm-logger.service.spec.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmLoggerService } from './typeorm-logger.service';
 
@@ -65,6 +66,25 @@ describe('TypeOrmLoggerService', () => {
           [1],
         ),
       ).not.toThrow();
+    });
+
+    it('never writes parameter values to the log (no plaintext creds/PII)', () => {
+      const errorSpy = vi
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation(vi.fn());
+      const configService = createMockConfigService(['error']);
+      const service = new TypeOrmLoggerService(configService);
+
+      service.logQueryError(
+        new Error('Failed'),
+        'INSERT INTO `user`(`email`, `password`) VALUES (?, ?)',
+        ['victim@example.com', 'SuperSecret123!'],
+      );
+
+      const logged = errorSpy.mock.calls.flat().join(' ');
+      expect(logged).not.toContain('SuperSecret123!');
+      expect(logged).not.toContain('victim@example.com');
+      errorSpy.mockRestore();
     });
   });
 
@@ -154,75 +174,8 @@ describe('TypeOrmLoggerService', () => {
     });
   });
 
-  describe('stringifyParameter', () => {
-    it('should return NULL for null values', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter(null);
-      expect(result).toBe('NULL');
-    });
-
-    it('should return NULL for undefined values', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter(undefined);
-      expect(result).toBe('NULL');
-    });
-
-    it('should wrap string values in quotes', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter('test');
-      expect(result).toBe("'test'");
-    });
-
-    it('should escape single quotes in strings', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter("test'value");
-      expect(result).toBe("'test''value'");
-    });
-
-    it('should format Date values as ISO strings', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const date = new Date('2024-01-01T00:00:00Z');
-      const result = (service as any).stringifyParameter(date);
-      expect(result).toBe("'2024-01-01T00:00:00.000Z'");
-    });
-
-    it('should format arrays as bracketed lists', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter([1, 2, 3]);
-      expect(result).toBe('[1, 2, 3]');
-    });
-
-    it('should format objects as JSON', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter({ key: 'value' });
-      expect(result).toBe('{"key":"value"}');
-    });
-
-    it('should convert numbers to strings', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      const result = (service as any).stringifyParameter(42);
-      expect(result).toBe('42');
-    });
-  });
-
-  describe('buildSqlString', () => {
-    it('should return query without parameters if none provided', () => {
+  describe('buildSqlString (parameter redaction)', () => {
+    it('returns the query unchanged when no parameters are provided', () => {
       const configService = createMockConfigService(['query']);
       const service = new TypeOrmLoggerService(configService);
 
@@ -230,44 +183,31 @@ describe('TypeOrmLoggerService', () => {
       expect(result).toBe('SELECT * FROM users');
     });
 
-    it('should replace ? placeholders with parameters', () => {
+    it('never interpolates positional (?) parameter values', () => {
       const configService = createMockConfigService(['query']);
       const service = new TypeOrmLoggerService(configService);
 
       const result = (service as any).buildSqlString(
-        'SELECT * FROM users WHERE id = ? AND name = ?',
-        [1, 'test'],
+        'INSERT INTO `user`(`email`, `password`) VALUES (?, ?)',
+        ['victim@example.com', 'SuperSecret123!'],
       );
-      expect(result).toContain('1');
-      expect(result).toContain("'test'");
+
+      expect(result).not.toContain('SuperSecret123!');
+      expect(result).not.toContain('victim@example.com');
+      // Placeholders are preserved so the statement shape stays debuggable
+      expect(result).toContain('?');
     });
 
-    it('should handle named parameters', () => {
+    it('never interpolates named parameter values', () => {
       const configService = createMockConfigService(['query']);
       const service = new TypeOrmLoggerService(configService);
 
       const result = (service as any).buildSqlString(
-        'SELECT * FROM users WHERE id = :id',
-        [{ id: 1 }],
+        'SELECT * FROM `user` WHERE email = :email',
+        [{ email: 'victim@example.com' }],
       );
-      expect(result).toContain('1');
-    });
 
-    it('should return query with original params if replacement fails', () => {
-      const configService = createMockConfigService(['query']);
-      const service = new TypeOrmLoggerService(configService);
-
-      // Spy on stringifyParameter to make it throw
-      vi.spyOn(service as any, 'stringifyParameter').mockImplementation(() => {
-        throw new Error('Cannot stringify');
-      });
-
-      const result = (service as any).buildSqlString('SELECT * FROM users', [
-        { complex: 'object' },
-      ]);
-
-      expect(result).toContain('SELECT * FROM users');
-      expect(result).toContain('Parameters:');
+      expect(result).not.toContain('victim@example.com');
     });
   });
 });

--- a/src/database/logger/typeorm-logger.service.ts
+++ b/src/database/logger/typeorm-logger.service.ts
@@ -107,56 +107,17 @@ export class TypeOrmLoggerService implements TypeOrmLogger {
   }
 
   /**
-   * Build SQL string with parameters for logging
+   * Build the SQL string for logging.
+   *
+   * Security: bound parameter values are NEVER interpolated into the logged
+   * string — they can contain plaintext passwords or PII that would then leak
+   * into container logs / the logging stack. The parameterized query (with its
+   * placeholders) is logged as-is, with only a redacted parameter count.
    */
   private buildSqlString(query: string, parameters?: any[]): string {
     if (!parameters || !parameters.length) {
       return query;
     }
-
-    // Simple parameter replacement for logging
-    let sql = query;
-    try {
-      if (parameters && parameters.length) {
-        // Replace ? with parameter values
-        if (sql.includes('?')) {
-          parameters.forEach((param) => {
-            sql = sql.replace('?', this.stringifyParameter(param));
-          });
-        }
-        // For named parameters
-        else {
-          Object.keys(parameters[0]).forEach((key) => {
-            sql = sql.replace(
-              new RegExp(`:${key}\\b`, 'g'),
-              this.stringifyParameter(parameters[0][key]),
-            );
-          });
-        }
-      }
-    } catch {
-      // If parameter replacement fails, return original query with parameters
-      return `${query} -- Parameters: ${JSON.stringify(parameters)}`;
-    }
-
-    return sql;
-  }
-
-  /**
-   * Convert parameter to string for logging
-   */
-  private stringifyParameter(param: any): string {
-    if (param === null || param === undefined) {
-      return 'NULL';
-    } else if (typeof param === 'string') {
-      return `'${param.replace(/'/g, "''")}'`;
-    } else if (param instanceof Date) {
-      return `'${param.toISOString()}'`;
-    } else if (Array.isArray(param)) {
-      return `[${param.map((p) => this.stringifyParameter(p)).join(', ')}]`;
-    } else if (typeof param === 'object') {
-      return JSON.stringify(param);
-    }
-    return String(param);
+    return `${query} -- [${parameters.length} parameter(s) redacted]`;
   }
 }

--- a/src/users/entities/user.entity.spec.ts
+++ b/src/users/entities/user.entity.spec.ts
@@ -1,0 +1,25 @@
+import { User, ROLES } from './user.entity';
+
+describe('User entity', () => {
+  describe('assignDefaultRoles (@BeforeInsert)', () => {
+    it('defaults roles to [USER] when none are provided', () => {
+      const user = new User();
+      user.assignDefaultRoles();
+      expect(user.roles).toEqual([ROLES.USER]);
+    });
+
+    it('defaults roles to [USER] when an empty array is provided', () => {
+      const user = new User();
+      user.roles = [];
+      user.assignDefaultRoles();
+      expect(user.roles).toEqual([ROLES.USER]);
+    });
+
+    it('preserves explicitly provided roles', () => {
+      const user = new User();
+      user.roles = [ROLES.ADMIN];
+      user.assignDefaultRoles();
+      expect(user.roles).toEqual([ROLES.ADMIN]);
+    });
+  });
+});

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from '@core/entities/base.entity';
-import { Column, Entity } from 'typeorm';
+import { BeforeInsert, Column, Entity } from 'typeorm';
 
 export const ROLES = { ADMIN: 'admin', USER: 'user' } as const;
 export type Role = (typeof ROLES)[keyof typeof ROLES];
@@ -12,6 +12,15 @@ export class User extends BaseEntity {
   email: string;
   @Column({ nullable: false })
   password: string;
-  @Column({ type: 'simple-array', default: ROLES.USER })
+  // No DB-level default: MySQL/MariaDB can't apply DEFAULT to a TEXT
+  // (simple-array) column, so the default is assigned in app code below.
+  @Column({ type: 'simple-array' })
   roles: Role[];
+
+  @BeforeInsert()
+  assignDefaultRoles(): void {
+    if (!this.roles || this.roles.length === 0) {
+      this.roles = [ROLES.USER];
+    }
+  }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import * as bcrypt from 'bcrypt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { Repository } from 'typeorm';
@@ -39,30 +40,33 @@ describe('UsersService', () => {
   });
 
   describe('create', () => {
-    it('should create and return the new user', async () => {
+    it('should hash the password before persisting (never store plaintext)', async () => {
       const dto: CreateUserDto = {
         email: 'user@email.com',
         password: 'password123',
         username: 'testuser',
       };
 
-      const expectedUser: User = {
-        id: 1,
-        ...dto,
-      } as User;
-
-      vi.spyOn(repository, 'create').mockReturnValue(expectedUser);
-      vi.spyOn(repository, 'save').mockResolvedValue(expectedUser);
+      let captured: Partial<User> | undefined;
+      vi.spyOn(repository, 'create').mockImplementation((u) => {
+        captured = u as User;
+        return u as User;
+      });
+      vi.spyOn(repository, 'save').mockImplementation((u) =>
+        Promise.resolve(u as User),
+      );
 
       const result = await service.create(dto);
 
-      expect(result).toEqual(expectedUser);
-      expect(repository.create).toHaveBeenCalledWith({
-        email: dto.email,
-        password: dto.password,
-        username: dto.username,
-      });
-      expect(repository.save).toHaveBeenCalledWith(expectedUser);
+      expect(captured?.email).toBe(dto.email);
+      expect(captured?.username).toBe(dto.username);
+      // Password must be hashed, not the raw value
+      expect(captured?.password).toBeDefined();
+      expect(captured?.password).not.toBe('password123');
+      expect(await bcrypt.compare('password123', captured!.password!)).toBe(
+        true,
+      );
+      expect(result).toBeDefined();
     });
   });
 
@@ -170,7 +174,7 @@ describe('UsersService', () => {
       vi.spyOn(repository, 'save').mockResolvedValue({
         ...existingUser,
         ...updateDto,
-      });
+      } as User);
 
       const result = await service.update(1, updateDto);
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -69,7 +69,7 @@ export class UsersService {
   async create(createUserDto: CreateUserDto): Promise<User> {
     const user = this.userRepository.create({
       email: createUserDto.email,
-      password: createUserDto.password,
+      password: await bcrypt.hash(createUserDto.password, 10),
       username: createUserDto.username,
     });
     return this.userRepository.save(user);


### PR DESCRIPTION
Sprint 0 of the owner-authorized security assessment — the two High findings plus the Medium that masks one of them. All three live in the user-creation / logging path and are interdependent (order: H1 → M6).

## Fixes

**H1 — plaintext passwords (High)**
`UsersService.create()` bound the raw password into the INSERT, while `update()` and `AuthService.register()` both hashed. Hashing is now owned by `create()` (single insert path, hashes exactly once); `register()` forwards the raw password to avoid double-hashing.

**M6 — user creation 500 (Medium)**
`User.roles` used a TypeORM column `default` on a `simple-array` (TEXT) column, which MySQL/MariaDB can't apply → every insert failed (`Field 'roles' doesn't have a default value`), breaking both `/auth/register` and admin user creation. Default is now assigned in a `@BeforeInsert` hook. *(Fixed together with H1 so unblocking creation never persists a plaintext password.)*

**H2 — query parameters logged in plaintext (High)**
`TypeOrmLoggerService` interpolated bound parameter values into the logged SQL, so a failed query dumped plaintext passwords / PII into container logs. The logger now logs the parameterized query with placeholders only plus a redacted parameter count, and the prod migration DataSource no longer logs every query.

## Verification
- `npm test` — 534/534 green (added: create-hashing, register-raw-forward, `@BeforeInsert` default, logger redaction incl. a "never logs param values" regression test).
- `npm run typecheck` — clean.
- `npm run build` — clean.

Out of scope (separate work): M1–M5/M7 and the Low findings.