### PR TITLE
Sprint 1: lock down API surface (Swagger + health metrics)

### DIFF
--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
+import { ApiKeyGuard } from '@core/api-key.guard';
 
 describe('HealthController', () => {
   let controller: HealthController;
@@ -37,7 +38,12 @@ describe('HealthController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      // ApiKeyGuard needs ApiKeyService (not wired in this unit module); stub it.
+      // Guard application is asserted separately via the route-protection metadata tests.
+      .overrideGuard(ApiKeyGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<HealthController>(HealthController);
     healthCheckService = module.get<HealthCheckService>(HealthCheckService);
@@ -49,6 +55,28 @@ describe('HealthController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('route protection', () => {
+    const guardsOf = (method: keyof HealthController): unknown[] =>
+      Reflect.getMetadata(
+        '__guards__',
+        (HealthController.prototype as Record<string, any>)[method as string],
+      ) || [];
+
+    it('protects /health/detailed with the ApiKeyGuard (no infra metrics for anon)', () => {
+      expect(guardsOf('detailed')).toContain(ApiKeyGuard);
+    });
+
+    it('protects the legacy /health/check (same payload as detailed)', () => {
+      expect(guardsOf('check')).toContain(ApiKeyGuard);
+    });
+
+    it('keeps the k8s probes public (no guard on /health, /live, /ready)', () => {
+      for (const m of ['health', 'liveness', 'readiness'] as const) {
+        expect(guardsOf(m)).not.toContain(ApiKeyGuard);
+      }
+    });
   });
 
   afterEach(() => {

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiExcludeEndpoint,
+  ApiSecurity,
 } from '@nestjs/swagger';
+import { ApiKeyGuard } from '@core/api-key.guard';
 import {
   HealthCheck,
   HealthCheckService,
@@ -82,6 +84,8 @@ export class HealthController {
    */
   @Get('detailed')
   @SkipThrottle()
+  @UseGuards(ApiKeyGuard)
+  @ApiSecurity('x-api-key')
   @ApiOperation({
     summary: 'Get detailed health status with metrics',
     description:
@@ -151,6 +155,7 @@ export class HealthController {
    */
   @Get('check')
   @SkipThrottle()
+  @UseGuards(ApiKeyGuard)
   @ApiExcludeEndpoint()
   async check() {
     return this.healthService.getFullHealth();

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -3,11 +3,13 @@ import { TerminusModule } from '@nestjs/terminus';
 import { HttpModule } from '@nestjs/axios';
 import { HealthController } from '@health/health.controller';
 import { HealthService } from '@health/health.service';
+import { ApiKeyModule } from '@core/api-key.module';
+import { ApiKeyGuard } from '@core/api-key.guard';
 
 @Module({
-  imports: [TerminusModule, HttpModule],
+  imports: [TerminusModule, HttpModule, ApiKeyModule],
   controllers: [HealthController],
-  providers: [HealthService],
+  providers: [HealthService, ApiKeyGuard],
   exports: [HealthService],
 })
 export class HealthModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -151,17 +151,23 @@ Paginated endpoints include \`meta.pagination\` with:
     .addTag('Chat', 'AI assistant endpoints')
     .build();
 
-  const documentFactory = () => SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('docs', app, documentFactory, {
-    swaggerOptions: {
-      persistAuthorization: true, // Keep auth token in Swagger UI
-      displayRequestDuration: true, // Show request duration
-      filter: true, // Enable filter/search
-      showExtensions: true,
-      showCommonExtensions: true,
-    },
-    customSiteTitle: 'Portfolio API Documentation',
-  });
+  // Never expose the API map (/docs, /docs-json) in production — it inventories
+  // every admin/users/api-keys/auth route for an attacker. Keep it in dev/staging.
+  if (appConfig.nodeEnv !== 'production') {
+    const documentFactory = () => SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('docs', app, documentFactory, {
+      swaggerOptions: {
+        persistAuthorization: true, // Keep auth token in Swagger UI
+        displayRequestDuration: true, // Show request duration
+        filter: true, // Enable filter/search
+        showExtensions: true,
+        showCommonExtensions: true,
+      },
+      customSiteTitle: 'Portfolio API Documentation',
+    });
+  } else {
+    Logger.log('Swagger docs disabled in production', 'Bootstrap');
+  }
 
   const port = appConfig.port;
   Logger.log(`Starting server on port ${port}`, 'Bootstrap');


### PR DESCRIPTION
Sprint 1 — API surface hardening. Two independent, low-risk fixes that remove unauthenticated recon surface. (M1 chatbot hardening and M5 frontend CSP come in separate PRs; M4 turned out to be already implemented in code — verifying in prod separately.)

## Fixes

**M2 — Swagger public in prod (Medium)**
The single public `/docs` (+ `/docs-json`) exposed the full API map — every admin/users, api-keys and auth route. `SwaggerModule.setup` is now gated behind `NODE_ENV` so docs stay in dev/staging but are never served in prod.

**M3 — `/health/detailed` unauthenticated infra disclosure (Medium)**
`/health/detailed` (and the legacy `/health/check`, same payload) leaked version, uptime, process cpu/memory and DB/Redis latency to anyone. Both are now guarded with `ApiKeyGuard`; the k8s probes (`/health`, `/health/live`, `/health/ready`) stay public and minimal. The frontend BFF already forwards `x-api-key` (`server/api/health/detailed.get.ts`), so **no frontend change needed**.

## Verification
- `npm test` — 539/539 green (added route-protection tests asserting the guard is on detailed + check and absent on the public probes).
- `npm run typecheck` — clean.
- `npm run build` — clean.

Decision rationale (M2): disable-in-prod chosen over auth-gating (you already have docs locally) and curated-public (a product feature, not a security fix — and reintroduces the "forgot to exclude a route" leak class).