### PR TITLE
fix: throttler ttl was in milliseconds, so rate limits never fired

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,9 +68,12 @@ API_KEY_SECRET=your-api-key-secret-change-in-production
 # -------------------------------------------
 # Rate Limiting (Throttler)
 # -------------------------------------------
+# Window length in SECONDS (converted to ms internally).
 THROTTLE_TTL=60
+# Global default max requests per window.
 THROTTLE_LIMIT=10
 THROTTLE_PUBLIC_LIMIT=20
+# Strict per-IP requests/window for the public /chat endpoint.
 THROTTLE_STRICT_LIMIT=5
 
 # -------------------------------------------
@@ -84,8 +87,7 @@ CHAT_TEMPERATURE=0.3
 CHAT_MAX_COMPLETION_TOKENS=512
 # Answer cache TTL in seconds (CV is static — 24h)
 CHAT_CACHE_TTL=86400
-# Strict per-IP requests/min for the public /chat endpoint
-CHAT_STRICT_LIMIT=5
+# NOTE: the public /chat per-IP limit is THROTTLE_STRICT_LIMIT (see above).
 
 # -------------------------------------------
 # Production Secrets (GitHub Actions)

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,7 +8,7 @@ import {
   HttpStatus,
   Get,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
+import { Throttle, seconds } from '@nestjs/throttler';
 import { ErrorCode, ErrorResponseDto, SuccessResponseDto } from '@core/dto';
 import { AuthService } from '@auth/auth.service';
 import {
@@ -41,7 +41,7 @@ export class AuthController {
    */
   @HttpCode(HttpStatus.OK)
   @Post('login')
-  @Throttle({ default: { limit: 5, ttl: 60 } }) // 5 requests per minute for login (prevent brute force)
+  @Throttle({ default: { limit: 5, ttl: seconds(60) } }) // 5 requests per minute for login (prevent brute force)
   @ApiOperation({ summary: 'User Login' })
   @ApiCustomResponses(
     ApiResponse({
@@ -77,7 +77,7 @@ export class AuthController {
 
   @HttpCode(HttpStatus.OK)
   @Post('register')
-  @Throttle({ default: { limit: 5, ttl: 60 } }) // 5 requests per minute for registration (prevent abuse)
+  @Throttle({ default: { limit: 5, ttl: seconds(60) } }) // 5 requests per minute for registration (prevent abuse)
   @ApiOperation({ summary: 'User Registration' })
   @ApiCustomResponses(
     ApiResponse({

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -6,7 +6,7 @@ import {
   ApiTags,
   ApiTooManyRequestsResponse,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
+import { Throttle, seconds } from '@nestjs/throttler';
 import { Public } from '@auth/decorators/public.decorator';
 import { ChatService } from './chat.service';
 import { AskChatDto, ChatResponseDto } from './dto';
@@ -28,7 +28,7 @@ export class ChatController {
   @Post()
   @Public()
   @HttpCode(HttpStatus.OK)
-  @Throttle({ default: { limit: CHAT_STRICT_LIMIT, ttl: 60 } })
+  @Throttle({ default: { limit: CHAT_STRICT_LIMIT, ttl: seconds(60) } })
   @ApiOperation({
     summary: 'Ask the portfolio assistant a question about Carlos',
   })

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -14,8 +14,8 @@ import { AskChatDto, ChatResponseDto } from './dto';
 // Strict per-IP limit for this public, quota-bearing endpoint. Read at module
 // load because @Throttle is evaluated statically. Guard against a non-numeric
 // or non-positive env value (NaN would make the throttle behavior undefined).
-const PARSED_STRICT_LIMIT = Number(process.env.CHAT_STRICT_LIMIT);
-const CHAT_STRICT_LIMIT =
+const PARSED_STRICT_LIMIT = Number(process.env.THROTTLE_STRICT_LIMIT);
+const STRICT_LIMIT =
   Number.isFinite(PARSED_STRICT_LIMIT) && PARSED_STRICT_LIMIT > 0
     ? PARSED_STRICT_LIMIT
     : 5;
@@ -28,7 +28,7 @@ export class ChatController {
   @Post()
   @Public()
   @HttpCode(HttpStatus.OK)
-  @Throttle({ default: { limit: CHAT_STRICT_LIMIT, ttl: seconds(60) } })
+  @Throttle({ default: { limit: STRICT_LIMIT, ttl: seconds(60) } })
   @ApiOperation({
     summary: 'Ask the portfolio assistant a question about Carlos',
   })

--- a/src/config/configuration.loaders.spec.ts
+++ b/src/config/configuration.loaders.spec.ts
@@ -4,6 +4,7 @@ import {
   loadDatabaseConfig,
   loadRedisConfig,
   loadJwtConfig,
+  loadThrottlerConfig,
 } from './configuration.loaders';
 
 describe('configuration.loaders', () => {
@@ -302,6 +303,32 @@ describe('configuration.loaders', () => {
       const config = loadJwtConfig();
 
       expect(config.secret).toBe('my-quoted-secret');
+    });
+  });
+
+  describe('loadThrottlerConfig', () => {
+    // @nestjs/throttler v5+ expects ttl in MILLISECONDS. THROTTLE_TTL is
+    // authored in seconds for readability, so the loader must convert it.
+    // Before this fix the loader returned raw seconds (60), which the library
+    // read as 60ms — a window so short the limit could never be reached and
+    // throttling never fired.
+    it('should default ttl to 60 seconds expressed in milliseconds', () => {
+      delete process.env.THROTTLE_TTL;
+      delete process.env.THROTTLE_LIMIT;
+
+      const config = loadThrottlerConfig();
+
+      expect(config).toEqual({ ttl: 60000, limit: 100 });
+    });
+
+    it('should convert a custom THROTTLE_TTL (seconds) to milliseconds', () => {
+      process.env.THROTTLE_TTL = '30';
+      process.env.THROTTLE_LIMIT = '25';
+
+      const config = loadThrottlerConfig();
+
+      expect(config.ttl).toBe(30000);
+      expect(config.limit).toBe(25);
     });
   });
 });

--- a/src/config/configuration.loaders.ts
+++ b/src/config/configuration.loaders.ts
@@ -1,4 +1,5 @@
 import { LogLevel } from 'typeorm';
+import { seconds } from '@nestjs/throttler';
 import { parseEnvBoolean, parseEnvInt, trimEnvQuotes } from '@config/env.utils';
 import type {
   AppConfig,
@@ -88,7 +89,10 @@ export function loadJwtConfig(): JwtConfig {
 
 export function loadThrottlerConfig(): ThrottlerConfig {
   return {
-    ttl: parseEnvInt(process.env.THROTTLE_TTL, 60), // seconds (NestJS throttler v6+ uses seconds)
+    // @nestjs/throttler v5+ expects ttl in MILLISECONDS. THROTTLE_TTL is
+    // authored in seconds for readability, so convert it with seconds().
+    // (Passing raw seconds made the window 60ms — throttling never fired.)
+    ttl: seconds(parseEnvInt(process.env.THROTTLE_TTL, 60)),
     limit: parseEnvInt(process.env.THROTTLE_LIMIT, 100),
   };
 }

--- a/src/config/configuration.types.ts
+++ b/src/config/configuration.types.ts
@@ -43,7 +43,7 @@ export interface JwtConfig {
 }
 
 export interface ThrottlerConfig {
-  /** Window duration in seconds (NestJS throttler v6+ uses seconds, not milliseconds) */
+  /** Window duration in MILLISECONDS — the unit @nestjs/throttler v5+ expects. loadThrottlerConfig converts THROTTLE_TTL (seconds) via the seconds() helper. */
   ttl: number;
   /** Max requests per window for authenticated endpoints */
   limit: number;

--- a/src/contacts/contacts.controller.ts
+++ b/src/contacts/contacts.controller.ts
@@ -10,7 +10,7 @@ import {
   Patch,
   ParseIntPipe,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
+import { Throttle, seconds } from '@nestjs/throttler';
 import {
   ApiOperation,
   ApiParam,
@@ -46,7 +46,7 @@ export class ContactsController {
 
   @Post()
   @Public()
-  @Throttle({ default: { limit: 10, ttl: 60 } }) // 10 requests per minute for public contact form
+  @Throttle({ default: { limit: 10, ttl: seconds(60) } }) // 10 requests per minute for public contact form
   @ApiOperation({ summary: 'Submit a contact form' })
   @ApiBody({ type: CreateContactDto })
   @ApiCreateResource(

--- a/src/core/throttler/throttler.module.spec.ts
+++ b/src/core/throttler/throttler.module.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { AppThrottlerModule } from './throttler.module';
-import { loadThrottlerConfig } from '@config/configuration.loaders';
 
 describe('AppThrottlerModule', () => {
   let module: TestingModule;
@@ -19,37 +18,5 @@ describe('AppThrottlerModule', () => {
   it('should export ThrottlerModule', () => {
     const throttlerModule = module.get(ThrottlerModule);
     expect(throttlerModule).toBeDefined();
-  });
-});
-
-describe('loadThrottlerConfig', () => {
-  const ORIGINAL_ENV = process.env;
-
-  beforeEach(() => {
-    process.env = { ...ORIGINAL_ENV };
-  });
-
-  afterEach(() => {
-    process.env = ORIGINAL_ENV;
-  });
-
-  it('should return defaults when env vars are unset', () => {
-    delete process.env.THROTTLE_TTL;
-    delete process.env.THROTTLE_LIMIT;
-
-    const config = loadThrottlerConfig();
-
-    expect(config.ttl).toBe(60);
-    expect(config.limit).toBe(100);
-  });
-
-  it('should read values from env vars', () => {
-    process.env.THROTTLE_TTL = '120';
-    process.env.THROTTLE_LIMIT = '200';
-
-    const config = loadThrottlerConfig();
-
-    expect(config.ttl).toBe(120);
-    expect(config.limit).toBe(200);
   });
 });

--- a/src/core/throttler/throttler.module.ts
+++ b/src/core/throttler/throttler.module.ts
@@ -24,9 +24,10 @@ const throttlerConfig = loadThrottlerConfig();
  * authored in seconds (default: 60) and converted to ms by loadThrottlerConfig
  * via the throttler's seconds() helper.
  *
- * For specific limits, use @Throttle decorator on controllers:
- * - Public endpoints: @Throttle({ default: { limit: publicLimit, ttl: 60 } })
- * - Auth endpoints:   @Throttle({ default: { limit: strictLimit, ttl: 60 } })
+ * For specific limits, use @Throttle decorator on controllers (ttl in ms — use
+ * the seconds() helper for readability):
+ * - Public endpoints: @Throttle({ default: { limit: publicLimit, ttl: seconds(60) } })
+ * - Auth endpoints:   @Throttle({ default: { limit: strictLimit, ttl: seconds(60) } })
  */
 @Global()
 @Module({
@@ -34,7 +35,7 @@ const throttlerConfig = loadThrottlerConfig();
     ThrottlerModule.forRoot({
       throttlers: [
         {
-          ttl: throttlerConfig.ttl, // seconds
+          ttl: throttlerConfig.ttl, // milliseconds (loadThrottlerConfig already converted)
           limit: throttlerConfig.limit,
         },
       ],

--- a/src/core/throttler/throttler.module.ts
+++ b/src/core/throttler/throttler.module.ts
@@ -20,8 +20,9 @@ const throttlerConfig = loadThrottlerConfig();
  * Rate limiting configuration (global default):
  * - Default: 100 requests per 60 seconds (for authenticated endpoints)
  *
- * NOTE: NestJS throttler v6+ uses seconds for ttl, not milliseconds.
- * THROTTLE_TTL env var must be set in seconds (default: 60).
+ * NOTE: NestJS throttler v5+ uses MILLISECONDS for ttl. THROTTLE_TTL is
+ * authored in seconds (default: 60) and converted to ms by loadThrottlerConfig
+ * via the throttler's seconds() helper.
  *
  * For specific limits, use @Throttle decorator on controllers:
  * - Public endpoints: @Throttle({ default: { limit: publicLimit, ttl: 60 } })

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,9 @@ async function bootstrap() {
   // resolves the real client IP from X-Forwarded-For. The throttler tracks
   // per-IP — without this every request would carry the proxy's IP and the
   // whole site would share one rate-limit bucket.
+  // NOTE: `1` trusts exactly one hop. For the per-IP throttle to be
+  // tamper-proof, Traefik must overwrite (not append to) X-Forwarded-For so a
+  // client can't spoof it to rotate IPs and evade the limit.
   app.set('trust proxy', 1);
 
   // Mount CLS middleware first - before any other middleware that depends on it

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from '@src/app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from '@nestjs/common';
@@ -9,7 +10,13 @@ import { ClsMiddleware } from 'nestjs-cls';
 import helmet from 'helmet';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  // Trust the single reverse proxy (Traefik) in front of the app so Express
+  // resolves the real client IP from X-Forwarded-For. The throttler tracks
+  // per-IP — without this every request would carry the proxy's IP and the
+  // whole site would share one rate-limit bucket.
+  app.set('trust proxy', 1);
 
   // Mount CLS middleware first - before any other middleware that depends on it
   // This ensures CLS context is available for RequestIdMiddleware and others


### PR DESCRIPTION
## Why

Closes security finding **M4** (no effective rate limiting) — and turned out to be bigger than the chat endpoint.

`@nestjs/throttler` v5+ reads `ttl` in **milliseconds**, but `loadThrottlerConfig` and every `@Throttle` decorator passed raw seconds (`ttl: 60`). The library treated that as a **60 ms window** that resets ~16×/second, so no client ever accumulated enough requests to trip the limit. Throttling **silently never fired in production**:

- `/auth/login` + `/auth/register` brute-force protection (limit 5) — dead
- public `/chat` cost guard (limit 5) — dead (the reported M4)
- `/contacts` form-abuse guard (limit 10) — dead
- global default (`THROTTLE_LIMIT`) — dead

Root-caused on prod: 7 rapid requests to `api.cativo.dev/api/v1/chat` (and direct-to-container, bypassing Traefik) never returned 429; response headers showed `X-RateLimit-Reset: 1`, confirming a sub-second window. Verified locally against the installed `@nestjs/throttler@6.5.0` (`seconds(60) === 60000`; README: *"the `ttl` is now in milliseconds"*).

## What

1. **`fix`: ttl unit** — wrap ttl with the throttler's `seconds()` helper in `loadThrottlerConfig` and the auth/chat/contacts decorators; correct the inverted unit comment in the throttler module.
2. **`fix`: trust proxy** — `app.set('trust proxy', 1)` in `main.ts`. The app sits behind a single Traefik proxy; without this, once throttling actually fires it would bucket every visitor under the proxy's IP. Now the per-IP limiter reads the real client IP from `X-Forwarded-For`.
3. **`refactor`: env var** — the `/chat` limit was read from `CHAT_STRICT_LIMIT`, but the deploy pipeline only ever set `THROTTLE_STRICT_LIMIT` (so the configured value was silently ignored). Standardized on the `THROTTLE_*` family already written by `deploy.yml`; cleaned up `.env.example`.
4. **`test`**: loader now asserts the millisecond contract (`configuration.loaders.spec.ts`); removed the stale duplicate in the module spec.

## Verify
- `format:check`, `lint`, `typecheck`, `test:cov` (539 passed) — all green locally.
- **Closes M4 only after deploy to `main` + prod re-verify**: 6th request to `/api/v1/chat` within 60 s should return 429, and a real visitor IP (not Traefik's) should be the throttle key.

## Notes / follow-ups
- `THROTTLE_PUBLIC_LIMIT` is written to prod `.env` but no code reads it (dead config) — left as-is; worth wiring or removing later.
- Throttler still uses in-memory storage (fine for the single prod replica; revisit if it ever scales horizontally).