### PR TITLE
Release 2.9.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,6 @@ API_KEY_SECRET=your-api-key-secret-change-in-production
 THROTTLE_TTL=60
 # Global default max requests per window.
 THROTTLE_LIMIT=10
-THROTTLE_PUBLIC_LIMIT=20
 # Strict per-IP requests/window for the public /chat endpoint.
 THROTTLE_STRICT_LIMIT=5
 
@@ -109,5 +108,4 @@ CHAT_CACHE_TTL=86400
 # - REDIS_TTL
 # - THROTTLE_TTL
 # - THROTTLE_LIMIT
-# - THROTTLE_PUBLIC_LIMIT
 # - THROTTLE_STRICT_LIMIT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ vars.DEPLOY_PORT }}
-          envs: DOCKER_USERNAME,DB_USERNAME,DB_PASSWORD,DB_NAME,MYSQL_ROOT_PASSWORD,JWT_SECRET,JWT_EXPIRES_IN,CORS_ORIGINS,API_KEY_SECRET,REDIS_PASSWORD,REDIS_TTL,THROTTLE_TTL,THROTTLE_LIMIT,THROTTLE_PUBLIC_LIMIT,THROTTLE_STRICT_LIMIT,GROQ_API_KEY
+          envs: DOCKER_USERNAME,DB_USERNAME,DB_PASSWORD,DB_NAME,MYSQL_ROOT_PASSWORD,JWT_SECRET,JWT_EXPIRES_IN,CORS_ORIGINS,API_KEY_SECRET,REDIS_PASSWORD,REDIS_TTL,THROTTLE_TTL,THROTTLE_LIMIT,THROTTLE_STRICT_LIMIT,GROQ_API_KEY
           script: |
             # Docker and database credentials
             export DOCKER_USERNAME="${{ secrets.DOCKER_USERNAME }}"
@@ -100,7 +100,6 @@ jobs:
             export REDIS_TTL="${{ vars.REDIS_TTL || 300 }}"
             export THROTTLE_TTL="${{ vars.THROTTLE_TTL || 60 }}"
             export THROTTLE_LIMIT="${{ vars.THROTTLE_LIMIT || 10 }}"
-            export THROTTLE_PUBLIC_LIMIT="${{ vars.THROTTLE_PUBLIC_LIMIT || 20 }}"
             export THROTTLE_STRICT_LIMIT="${{ vars.THROTTLE_STRICT_LIMIT || 5 }}"
 
             cd /home/cativo23/deploy/portfolio-api-deploy
@@ -123,7 +122,6 @@ jobs:
             echo "REDIS_TTL=${REDIS_TTL}" >> .env
             echo "THROTTLE_TTL=${THROTTLE_TTL}" >> .env
             echo "THROTTLE_LIMIT=${THROTTLE_LIMIT}" >> .env
-            echo "THROTTLE_PUBLIC_LIMIT=${THROTTLE_PUBLIC_LIMIT}" >> .env
             echo "THROTTLE_STRICT_LIMIT=${THROTTLE_STRICT_LIMIT}" >> .env
 
             # Login to Docker Hub on server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.1] - 2026-06-04
+
+### Changed
+
+- **Removed dead `THROTTLE_PUBLIC_LIMIT` config** — the deploy pipeline wrote `THROTTLE_PUBLIC_LIMIT` to the server `.env`, but no code ever read it. There is no "public" route tier: public endpoints either carry an explicit `@Throttle` (`/chat` reads `THROTTLE_STRICT_LIMIT`; `/contacts`, `/auth/login`, `/auth/register` hardcode their limits) or fall back to the global `THROTTLE_LIMIT`. Dropped from `deploy.yml`, `.env.example`, and the README. No runtime change. (#132)
+
+---
+
 ## [2.9.0] - 2026-06-03
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ The following environment variables are required for the application to run:
 - `NODE_ENV` - (Optional) Environment (development/production). In development, CORS is more permissive
 - `THROTTLE_TTL` - (Optional) Rate limit time window in **seconds** (NestJS throttler v6+ uses seconds). Defaults to `60` (1 minute)
 - `THROTTLE_LIMIT` - (Optional) Default rate limit (requests per window). Defaults to `100`
-- `THROTTLE_PUBLIC_LIMIT` - (Optional) Rate limit for public endpoints. Defaults to `10`
 - `THROTTLE_STRICT_LIMIT` - (Optional) Rate limit for auth endpoints (login/register). Defaults to `5`
 
 ## Project Setup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Production NestJS REST API — JWT auth, TypeORM, rate limiting, Docker, 90%+ test coverage",
   "author": "",
   "private": true,


### PR DESCRIPTION
## Summary

Removed the unused `THROTTLE_PUBLIC_LIMIT` environment variable that was written by the deploy pipeline but never read by the application. No runtime impact — the code uses explicit per-route throttle limits (`@Throttle` on `/chat`, hardcoded on `/contacts`, `/auth/login`, `/auth/register`) or falls back to the global limit.

## Highlights

- **Removed dead `THROTTLE_PUBLIC_LIMIT` config** — the deploy pipeline wrote `THROTTLE_PUBLIC_LIMIT` to the server `.env`, but no code ever read it. There is no "public" route tier: public endpoints either carry an explicit `@Throttle` (`/chat` reads `THROTTLE_STRICT_LIMIT`; `/contacts`, `/auth/login`, `/auth/register` hardcode their limits) or fall back to the global `THROTTLE_LIMIT`. Dropped from `deploy.yml`, `.env.example`, and the README. No runtime change. (#132)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v2.9.1` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://api.cativo.dev/health` returns 200 and container is healthy
- [ ] Post-release: `main` merged back to `develop`

Refs #132