### PR TITLE
chore: document BFF trust-proxy invariant, align THROTTLE_LIMIT default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ API_KEY_SECRET=your-api-key-secret-change-in-production
 # Window length in SECONDS (converted to ms internally).
 THROTTLE_TTL=60
 # Global default max requests per window.
-THROTTLE_LIMIT=10
+THROTTLE_LIMIT=100
 # Strict per-IP requests/window for the public /chat endpoint.
 THROTTLE_STRICT_LIMIT=5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
             # Configuration variables (use GitHub vars or defaults)
             export REDIS_TTL="${{ vars.REDIS_TTL || 300 }}"
             export THROTTLE_TTL="${{ vars.THROTTLE_TTL || 60 }}"
-            export THROTTLE_LIMIT="${{ vars.THROTTLE_LIMIT || 10 }}"
+            export THROTTLE_LIMIT="${{ vars.THROTTLE_LIMIT || 100 }}"
             export THROTTLE_STRICT_LIMIT="${{ vars.THROTTLE_STRICT_LIMIT || 5 }}"
 
             cd /home/cativo23/deploy/portfolio-api-deploy

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,19 @@ async function bootstrap() {
   // NOTE: `1` trusts exactly one hop. For the per-IP throttle to be
   // tamper-proof, Traefik must overwrite (not append to) X-Forwarded-For so a
   // client can't spoof it to rotate IPs and evade the limit.
+  //
+  // There are TWO request paths to this API and BOTH are exactly one proxy hop,
+  // so `1` is correct for each:
+  //   1. Public:  browser -> Traefik -> api          (Traefik sets XFF)
+  //   2. BFF:     browser -> Traefik -> Nuxt -> api   (the Nuxt BFF reaches us
+  //      directly over the internal docker network, bypassing Traefik, and
+  //      forwards a single clean X-Forwarded-For = the real client IP via its
+  //      apiFetch helper). Without that forwarding, all frontend traffic would
+  //      bucket under the Nuxt container's IP.
+  // LOAD-BEARING: path 2 is only safe because Traefik strips client-supplied XFF
+  // at the edge, so the BFF reads the true client IP. Do NOT add a second proxy
+  // hop on either path, and do NOT enable forwardedHeaders/insecure on the
+  // Traefik edge, without re-verifying this value and the BFF assumption.
   app.set('trust proxy', 1);
 
   // Mount CLS middleware first - before any other middleware that depends on it


### PR DESCRIPTION
## Why
Follow-up to the frontend change (cativo23/portfolio#132) that makes the BFF forward the real client IP. Two small, related cleanups.

## What
1. **`docs(main)`** — document the second request path in the `trust proxy` comment: the Nuxt BFF reaches this API directly over the internal docker network and forwards a single clean `X-Forwarded-For`. Both the public (via Traefik) and BFF paths are exactly one proxy hop, so `trust proxy 1` stays correct. Records the **load-bearing** dependency on Traefik stripping client XFF at the edge — so a future change doesn't silently make the throttle spoofable or single-bucketed.
2. **`chore(throttle)`** — align `THROTTLE_LIMIT` default to **100** across all four sources. It was 100 in code (`configuration.loaders`) and the README but **10** in `.env.example` and the `deploy.yml` fallback, so prod silently ran at 10. Now that throttling is per-visitor, 10/min is too low for normal browsing.

## Notes
- No code-behavior change in commit 1 (comment only); `trust proxy` value unchanged.
- Commit 2 changes the prod global limit 10→100 **on next deploy** (per-visitor, not global).

## Verification
Backend honoring of the BFF-forwarded XFF verified empirically against prod (distinct XFF on the internal hop → separate buckets; same XFF → throttles after the limit).