### PR TITLE
Release 2.11.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ API_KEY_SECRET=your-api-key-secret-change-in-production
 # Window length in SECONDS (converted to ms internally).
 THROTTLE_TTL=60
 # Global default max requests per window.
-THROTTLE_LIMIT=10
+THROTTLE_LIMIT=100
 # Strict per-IP requests/window for the public /chat endpoint.
 THROTTLE_STRICT_LIMIT=5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
             # Configuration variables (use GitHub vars or defaults)
             export REDIS_TTL="${{ vars.REDIS_TTL || 300 }}"
             export THROTTLE_TTL="${{ vars.THROTTLE_TTL || 60 }}"
-            export THROTTLE_LIMIT="${{ vars.THROTTLE_LIMIT || 10 }}"
+            export THROTTLE_LIMIT="${{ vars.THROTTLE_LIMIT || 100 }}"
             export THROTTLE_STRICT_LIMIT="${{ vars.THROTTLE_STRICT_LIMIT || 5 }}"
 
             cd /home/cativo23/deploy/portfolio-api-deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] - 2026-06-08
+
+### Changed
+- **`THROTTLE_LIMIT` default raised to 100** across code, README, `.env.example`, and the deploy pipeline. It read 100 in code/README but 10 in `.env.example`/`deploy.yml`, so production silently ran the global limit at 10. Paired with the frontend now forwarding the real client IP (so per-IP throttling is genuinely per-visitor), 10/min was too low for normal browsing. (#135)
+- **Documented the trust-proxy invariant in `main.ts`** — the Nuxt BFF reaches this API over the internal docker network (bypassing Traefik) and forwards a single clean `X-Forwarded-For` = the real client IP; both the public (via Traefik) and BFF paths are exactly one proxy hop, so `trust proxy 1` stays correct. Records the load-bearing dependency on Traefik stripping client-supplied XFF at the edge. No behavior change. (#135)
+
+---
+
 ## [2.10.0] - 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 </div>
 
 <!-- istanbul-badges-readme-start -->
-[![Lines](https://img.shields.io/badge/lines-96.74%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
-[![Statements](https://img.shields.io/badge/statements-96.52%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
-[![Branches](https://img.shields.io/badge/branches-91.48%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
-[![Functions](https://img.shields.io/badge/functions-93.11%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
+[![Lines](https://img.shields.io/badge/lines-96.76%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
+[![Statements](https://img.shields.io/badge/statements-96.54%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
+[![Branches](https://img.shields.io/badge/branches-91.56%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
+[![Functions](https://img.shields.io/badge/functions-93.17%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
 <!-- istanbul-badges-readme-end -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D23.0.0-brightgreen.svg)](https://nodejs.org/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Production NestJS REST API — JWT auth, TypeORM, rate limiting, Docker, 90%+ test coverage",
   "author": "",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,19 @@ async function bootstrap() {
   // NOTE: `1` trusts exactly one hop. For the per-IP throttle to be
   // tamper-proof, Traefik must overwrite (not append to) X-Forwarded-For so a
   // client can't spoof it to rotate IPs and evade the limit.
+  //
+  // There are TWO request paths to this API and BOTH are exactly one proxy hop,
+  // so `1` is correct for each:
+  //   1. Public:  browser -> Traefik -> api          (Traefik sets XFF)
+  //   2. BFF:     browser -> Traefik -> Nuxt -> api   (the Nuxt BFF reaches us
+  //      directly over the internal docker network, bypassing Traefik, and
+  //      forwards a single clean X-Forwarded-For = the real client IP via its
+  //      apiFetch helper). Without that forwarding, all frontend traffic would
+  //      bucket under the Nuxt container's IP.
+  // LOAD-BEARING: path 2 is only safe because Traefik strips client-supplied XFF
+  // at the edge, so the BFF reads the true client IP. Do NOT add a second proxy
+  // hop on either path, and do NOT enable forwardedHeaders/insecure on the
+  // Traefik edge, without re-verifying this value and the BFF assumption.
   app.set('trust proxy', 1);
 
   // Mount CLS middleware first - before any other middleware that depends on it


### PR DESCRIPTION
## Summary

Global rate-limit default raised from 10 to 100 req/min. The code and README specified 100, but the deploy pipeline and `.env.example` had 10, so production silently ran at the lower limit. With the frontend now forwarding real client IPs, per-IP throttling is more granular and 10/min was too restrictive. Also documented the trust-proxy invariant in main.ts for clarity on the load-bearing dependency on Traefik.

## Highlights

- **`THROTTLE_LIMIT` default raised to 100** across code, README, `.env.example`, and the deploy pipeline. It read 100 in code/README but 10 in `.env.example`/`deploy.yml`, so production silently ran the global limit at 10. Paired with the frontend now forwarding the real client IP (so per-IP throttling is genuinely per-visitor), 10/min was too low for normal browsing. (#135)
- **Documented the trust-proxy invariant in `main.ts`** — the Nuxt BFF reaches this API over the internal docker network (bypassing Traefik) and forwards a single clean `X-Forwarded-For` = the real client IP; both the public (via Traefik) and BFF paths are exactly one proxy hop, so `trust proxy 1` stays correct. Records the load-bearing dependency on Traefik stripping client-supplied XFF at the edge. No behavior change. (#135)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v2.11.0` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://api.cativo.dev/health` returns 200
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`

Refs #135