### PR TITLE
✨ feat(infra): add live container/stack counts endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,14 @@ THROTTLE_LIMIT=100
 THROTTLE_STRICT_LIMIT=5
 
 # -------------------------------------------
+# Infra signal (live container/stack counts)
+# -------------------------------------------
+# Read-only docker-socket-proxy base URL. On the prod host both this API and the
+# proxy share the space-server_web network, so the service DNS name resolves.
+# Only the /containers/json list endpoint is called (see ADR-0004).
+DOCKER_PROXY_URL=http://dockerproxy:2375
+
+# -------------------------------------------
 # Chat (AI assistant — Groq, OpenAI-compatible)
 # -------------------------------------------
 # REQUIRED. Create a free key at https://console.groq.com/keys

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,7 +14,7 @@ import { ContactsModule } from '@contacts/contacts.module';
 import { ProfileModule } from '@profile/profile.module';
 import { EmailModule } from '@email/email.module';
 import { ChatModule } from '@chat/chat.module';
-import { InfraModule } from '@src/infra/infra.module';
+import { InfraModule } from '@infra/infra.module';
 import { RequestContextModule } from '@core/context/request-context.module';
 import { RequestIdMiddleware } from '@core/middleware/request-id.middleware';
 import { ResponseTransformInterceptor } from '@core/interceptors/response-transform.interceptor';

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { ContactsModule } from '@contacts/contacts.module';
 import { ProfileModule } from '@profile/profile.module';
 import { EmailModule } from '@email/email.module';
 import { ChatModule } from '@chat/chat.module';
+import { InfraModule } from '@src/infra/infra.module';
 import { RequestContextModule } from '@core/context/request-context.module';
 import { RequestIdMiddleware } from '@core/middleware/request-id.middleware';
 import { ResponseTransformInterceptor } from '@core/interceptors/response-transform.interceptor';
@@ -36,6 +37,7 @@ import { AppThrottlerModule } from '@core/throttler/throttler.module';
     ProfileModule,
     EmailModule,
     ChatModule,
+    InfraModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/config/app-configuration.module.ts
+++ b/src/config/app-configuration.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, registerAs } from '@nestjs/config';
 import {
   loadAppConfig,
   loadDatabaseConfig,
+  loadInfraConfig,
   loadJwtConfig,
   loadRedisConfig,
 } from '@config/configuration.loaders';
@@ -15,6 +16,7 @@ export const appConfiguration = registerAs('app', loadAppConfig);
 export const databaseConfiguration = registerAs('database', loadDatabaseConfig);
 export const redisConfiguration = registerAs('redis', loadRedisConfig);
 export const jwtConfiguration = registerAs('jwt', loadJwtConfig);
+export const infraConfiguration = registerAs('infra', loadInfraConfig);
 
 /**
  * Configuración tipada vía namespaces: `app`, `database`, `redis`, `jwt`.
@@ -33,6 +35,7 @@ export const jwtConfiguration = registerAs('jwt', loadJwtConfig);
         databaseConfiguration,
         redisConfiguration,
         jwtConfiguration,
+        infraConfiguration,
         apiKeyConfig,
         mailConfig,
         chatConfig,

--- a/src/config/configuration.loaders.ts
+++ b/src/config/configuration.loaders.ts
@@ -4,6 +4,7 @@ import { parseEnvBoolean, parseEnvInt, trimEnvQuotes } from '@config/env.utils';
 import type {
   AppConfig,
   DatabaseConfig,
+  InfraConfig,
   JwtConfig,
   RedisConfig,
   ThrottlerConfig,
@@ -84,6 +85,13 @@ export function loadJwtConfig(): JwtConfig {
   return {
     secret,
     expiresInSeconds: parseEnvInt(process.env.JWT_EXPIRES_IN, 3600),
+  };
+}
+
+export function loadInfraConfig(): InfraConfig {
+  return {
+    dockerProxyUrl:
+      trimEnvQuotes(process.env.DOCKER_PROXY_URL) || 'http://dockerproxy:2375',
   };
 }
 

--- a/src/config/configuration.types.ts
+++ b/src/config/configuration.types.ts
@@ -42,6 +42,15 @@ export interface JwtConfig {
   expiresInSeconds: number;
 }
 
+export interface InfraConfig {
+  /**
+   * Base URL of the read-only docker-socket-proxy (tecnativa/docker-socket-proxy).
+   * Used to derive live running-container and compose-stack counts for the
+   * public "SIGNAL" panel. Only the `/containers/json` list endpoint is called.
+   */
+  dockerProxyUrl: string;
+}
+
 export interface ThrottlerConfig {
   /** Window duration in MILLISECONDS — the unit @nestjs/throttler v5+ expects. loadThrottlerConfig converts THROTTLE_TTL (seconds) via the seconds() helper. */
   ttl: number;

--- a/src/infra/dto/infra-stats-response.dto.ts
+++ b/src/infra/dto/infra-stats-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Live infrastructure counts for the public SIGNAL panel.
+ * Fields are `null` when the docker proxy cannot be reached.
+ */
+export class InfraStatsResponseDto {
+  @ApiProperty({
+    description: 'Number of running containers',
+    nullable: true,
+    example: 20,
+  })
+  containers: number | null;
+
+  @ApiProperty({
+    description: 'Number of distinct docker-compose projects (stacks)',
+    nullable: true,
+    example: 12,
+  })
+  stacks: number | null;
+}

--- a/src/infra/infra.controller.spec.ts
+++ b/src/infra/infra.controller.spec.ts
@@ -1,0 +1,44 @@
+import { vi } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { InfraController } from './infra.controller';
+import { InfraService } from './infra.service';
+
+const mockInfraService = {
+  getStats: vi.fn(),
+};
+
+const mockCacheManager = {
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  stores: [],
+};
+
+describe('InfraController', () => {
+  let controller: InfraController;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InfraController],
+      providers: [
+        { provide: InfraService, useValue: mockInfraService },
+        { provide: CACHE_MANAGER, useValue: mockCacheManager },
+      ],
+    }).compile();
+
+    controller = module.get<InfraController>(InfraController);
+  });
+
+  it('returns the stats from the service', async () => {
+    mockInfraService.getStats.mockResolvedValue({ containers: 20, stacks: 12 });
+
+    await expect(controller.stats()).resolves.toEqual({
+      containers: 20,
+      stacks: 12,
+    });
+    expect(mockInfraService.getStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/infra/infra.controller.spec.ts
+++ b/src/infra/infra.controller.spec.ts
@@ -8,6 +8,9 @@ const mockInfraService = {
   getStats: vi.fn(),
 };
 
+// Required for DI: the controller is decorated with @UseInterceptors(CacheInterceptor),
+// so Nest instantiates CacheInterceptor (which injects CACHE_MANAGER) when compiling the
+// test module — even though the interceptor never runs during direct method calls.
 const mockCacheManager = {
   get: vi.fn(),
   set: vi.fn(),
@@ -40,5 +43,17 @@ describe('InfraController', () => {
       stacks: 12,
     });
     expect(mockInfraService.getStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes null counts through unchanged when the source is unreachable', async () => {
+    mockInfraService.getStats.mockResolvedValue({
+      containers: null,
+      stacks: null,
+    });
+
+    await expect(controller.stats()).resolves.toEqual({
+      containers: null,
+      stacks: null,
+    });
   });
 });

--- a/src/infra/infra.controller.ts
+++ b/src/infra/infra.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { CacheInterceptor, CacheKey, CacheTTL } from '@nestjs/cache-manager';
+import { SkipThrottle } from '@nestjs/throttler';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { InfraService } from './infra.service';
+import { InfraStatsResponseDto } from './dto/infra-stats-response.dto';
+
+/** Cache window for infra counts — they change rarely, so 5 min is plenty. */
+const INFRA_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Public infrastructure signal for the portfolio's SIGNAL panel.
+ *
+ * Exposes only aggregate counts (running containers, compose stacks) — the same
+ * numbers rendered publicly on the site — so there is no new information exposure.
+ */
+@ApiTags('Infra')
+@Controller('infra')
+export class InfraController {
+  constructor(private readonly infraService: InfraService) {}
+
+  @Get('stats')
+  @SkipThrottle()
+  @UseInterceptors(CacheInterceptor)
+  @CacheKey('infra:stats')
+  @CacheTTL(INFRA_CACHE_TTL_MS)
+  @ApiOperation({
+    summary: 'Live container and stack counts',
+    description:
+      'Running-container and docker-compose-stack counts derived from the ' +
+      'read-only docker-socket-proxy. Fields are null if the source is unreachable.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Infrastructure counts retrieved successfully',
+    type: InfraStatsResponseDto,
+  })
+  async stats(): Promise<InfraStatsResponseDto> {
+    return this.infraService.getStats();
+  }
+}

--- a/src/infra/infra.module.ts
+++ b/src/infra/infra.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { InfraController } from './infra.controller';
+import { InfraService } from './infra.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [InfraController],
+  providers: [InfraService],
+})
+export class InfraModule {}

--- a/src/infra/infra.service.spec.ts
+++ b/src/infra/infra.service.spec.ts
@@ -47,14 +47,15 @@ describe('InfraService', () => {
           container('portfolio'),
           container('space-server'),
           container('ghost'),
-          container(), // standalone container, no compose project
+          container(), // standalone container, empty Labels
+          {}, // container summary with no Labels key at all
         ],
       }),
     );
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: 5, stacks: 3 });
+    expect(stats).toEqual({ containers: 6, stacks: 3 });
     expect(mockHttpService.get).toHaveBeenCalledWith(
       'http://dockerproxy:2375/containers/json',
       expect.objectContaining({ timeout: expect.any(Number) }),

--- a/src/infra/infra.service.spec.ts
+++ b/src/infra/infra.service.spec.ts
@@ -1,0 +1,81 @@
+import { vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { InfraService } from './infra.service';
+
+const mockHttpService = {
+  get: vi.fn(),
+};
+
+const mockConfigService = {
+  getOrThrow: vi.fn().mockReturnValue({
+    dockerProxyUrl: 'http://dockerproxy:2375',
+  }),
+};
+
+function container(project?: string) {
+  return { Labels: project ? { 'com.docker.compose.project': project } : {} };
+}
+
+describe('InfraService', () => {
+  let service: InfraService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockConfigService.getOrThrow.mockReturnValue({
+      dockerProxyUrl: 'http://dockerproxy:2375',
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InfraService,
+        { provide: HttpService, useValue: mockHttpService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<InfraService>(InfraService);
+  });
+
+  it('counts running containers and distinct compose stacks', async () => {
+    mockHttpService.get.mockReturnValue(
+      of({
+        data: [
+          container('portfolio'),
+          container('portfolio'),
+          container('space-server'),
+          container('ghost'),
+          container(), // standalone container, no compose project
+        ],
+      }),
+    );
+
+    const stats = await service.getStats();
+
+    expect(stats).toEqual({ containers: 5, stacks: 3 });
+    expect(mockHttpService.get).toHaveBeenCalledWith(
+      'http://dockerproxy:2375/containers/json',
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it('degrades to nulls when the docker proxy is unreachable', async () => {
+    mockHttpService.get.mockReturnValue(
+      throwError(() => new Error('ECONNREFUSED')),
+    );
+
+    const stats = await service.getStats();
+
+    expect(stats).toEqual({ containers: null, stacks: null });
+  });
+
+  it('returns zeroes when no containers are running', async () => {
+    mockHttpService.get.mockReturnValue(of({ data: [] }));
+
+    const stats = await service.getStats();
+
+    expect(stats).toEqual({ containers: 0, stacks: 0 });
+  });
+});

--- a/src/infra/infra.service.ts
+++ b/src/infra/infra.service.ts
@@ -58,9 +58,8 @@ export class InfraService {
       return { containers, stacks };
     } catch (error) {
       // Decorative data: never let a proxy outage break the caller — degrade to nulls.
-      this.logger.warn(
-        `Failed to fetch docker stats: ${(error as Error).message}`,
-      );
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to fetch docker stats: ${message}`);
       return { containers: null, stacks: null };
     }
   }

--- a/src/infra/infra.service.ts
+++ b/src/infra/infra.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+import type { InfraConfig } from '@config/configuration.types';
+
+/** Live infrastructure counts surfaced on the public SIGNAL panel. */
+export interface InfraStats {
+  /** Running containers, or null when the docker proxy is unreachable. */
+  containers: number | null;
+  /** Distinct docker-compose projects (stacks), or null on failure. */
+  stacks: number | null;
+}
+
+/** Shape of a single entry from the docker `/containers/json` list endpoint. */
+interface DockerContainerSummary {
+  Labels?: Record<string, string>;
+}
+
+const COMPOSE_PROJECT_LABEL = 'com.docker.compose.project';
+const REQUEST_TIMEOUT_MS = 5000;
+
+/**
+ * Derives live container/stack counts from the read-only docker-socket-proxy.
+ *
+ * Only the `/containers/json` LIST endpoint is called — never `/containers/{id}/json`
+ * (inspect) — so no container env/mount detail is ever read (see ADR-0004).
+ */
+@Injectable()
+export class InfraService {
+  private readonly logger = new Logger(InfraService.name);
+  private readonly dockerProxyUrl: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    configService: ConfigService,
+  ) {
+    this.dockerProxyUrl =
+      configService.getOrThrow<InfraConfig>('infra').dockerProxyUrl;
+  }
+
+  async getStats(): Promise<InfraStats> {
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get<DockerContainerSummary[]>(
+          `${this.dockerProxyUrl}/containers/json`,
+          { timeout: REQUEST_TIMEOUT_MS },
+        ),
+      );
+
+      const containers = data.length;
+      const stacks = new Set(
+        data
+          .map((c) => c.Labels?.[COMPOSE_PROJECT_LABEL])
+          .filter((project): project is string => Boolean(project)),
+      ).size;
+
+      return { containers, stacks };
+    } catch (error) {
+      // Decorative data: never let a proxy outage break the caller — degrade to nulls.
+      this.logger.warn(
+        `Failed to fetch docker stats: ${(error as Error).message}`,
+      );
+      return { containers: null, stacks: null };
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
       "@database/*": ["src/database/*"],
       "@health/*": ["src/health/*"],
       "@chat/*": ["src/chat/*"],
+      "@infra/*": ["src/infra/*"],
       "@src/*": ["src/*"]
     },
     "resolveJsonModule": true


### PR DESCRIPTION
## What

New `GET /infra/stats` endpoint returning live `{ containers, stacks }` counts for the portfolio's public SIGNAL panel, replacing hardcoded numbers that had drifted from reality (site said 16/6; host runs ~20/12).

## How

- `InfraService` calls the existing read-only `docker-socket-proxy` (`dockerproxy:2375/containers/json`): running-container count = list length; stacks = distinct `com.docker.compose.project` labels.
- Only the **list** endpoint is called — never `/containers/{id}/json` (inspect) — so no container env is ever read.
- Public, `@SkipThrottle`, 5-min `CacheInterceptor`. Degrades to `null` counts on any proxy failure so the caller never breaks.
- `DOCKER_PROXY_URL` config (defaults to `http://dockerproxy:2375`). **Zero infra change** — the API already shares `space-server_web` with the proxy.

## Tests

- New `infra.service.spec` (count logic, failure→null, empty) + `infra.controller.spec`.
- Full suite: **576/576 pass** · `npm run typecheck` clean.

## Refs

- Rationale: space-server ADR-0004 (live infra signal via docker-socket-proxy).