### PR TITLE
feat(infra): count Traefik-exposed services, not raw containers

### DIFF
--- a/src/infra/dto/infra-stats-response.dto.ts
+++ b/src/infra/dto/infra-stats-response.dto.ts
@@ -6,11 +6,11 @@ import { ApiProperty } from '@nestjs/swagger';
  */
 export class InfraStatsResponseDto {
   @ApiProperty({
-    description: 'Number of running containers',
+    description: 'Number of Traefik-exposed services',
     nullable: true,
-    example: 20,
+    example: 17,
   })
-  containers: number | null;
+  services: number | null;
 
   @ApiProperty({
     description: 'Number of distinct docker-compose projects (stacks)',

--- a/src/infra/infra.controller.spec.ts
+++ b/src/infra/infra.controller.spec.ts
@@ -36,10 +36,10 @@ describe('InfraController', () => {
   });
 
   it('returns the stats from the service', async () => {
-    mockInfraService.getStats.mockResolvedValue({ containers: 20, stacks: 12 });
+    mockInfraService.getStats.mockResolvedValue({ services: 17, stacks: 12 });
 
     await expect(controller.stats()).resolves.toEqual({
-      containers: 20,
+      services: 17,
       stacks: 12,
     });
     expect(mockInfraService.getStats).toHaveBeenCalledTimes(1);
@@ -47,12 +47,12 @@ describe('InfraController', () => {
 
   it('passes null counts through unchanged when the source is unreachable', async () => {
     mockInfraService.getStats.mockResolvedValue({
-      containers: null,
+      services: null,
       stacks: null,
     });
 
     await expect(controller.stats()).resolves.toEqual({
-      containers: null,
+      services: null,
       stacks: null,
     });
   });

--- a/src/infra/infra.controller.ts
+++ b/src/infra/infra.controller.ts
@@ -11,8 +11,8 @@ const INFRA_CACHE_TTL_MS = 5 * 60 * 1000;
 /**
  * Public infrastructure signal for the portfolio's SIGNAL panel.
  *
- * Exposes only aggregate counts (running containers, compose stacks) — the same
- * numbers rendered publicly on the site — so there is no new information exposure.
+ * Exposes only aggregate counts (Traefik-exposed services, compose stacks) — the
+ * same numbers rendered publicly on the site — so there is no new information exposure.
  */
 @ApiTags('Infra')
 @Controller('infra')
@@ -25,9 +25,9 @@ export class InfraController {
   @CacheKey('infra:stats')
   @CacheTTL(INFRA_CACHE_TTL_MS)
   @ApiOperation({
-    summary: 'Live container and stack counts',
+    summary: 'Live service and stack counts',
     description:
-      'Running-container and docker-compose-stack counts derived from the ' +
+      'Traefik-exposed-service and docker-compose-stack counts derived from the ' +
       'read-only docker-socket-proxy. Fields are null if the source is unreachable.',
   })
   @ApiResponse({

--- a/src/infra/infra.service.spec.ts
+++ b/src/infra/infra.service.spec.ts
@@ -15,8 +15,11 @@ const mockConfigService = {
   }),
 };
 
-function container(project?: string) {
-  return { Labels: project ? { 'com.docker.compose.project': project } : {} };
+function container(project?: string, exposed = true) {
+  const labels: Record<string, string> = {};
+  if (project) labels['com.docker.compose.project'] = project;
+  if (exposed) labels['traefik.enable'] = 'true';
+  return { Labels: labels };
 }
 
 describe('InfraService', () => {
@@ -39,15 +42,16 @@ describe('InfraService', () => {
     service = module.get<InfraService>(InfraService);
   });
 
-  it('counts running containers and distinct compose stacks', async () => {
+  it('counts only Traefik-exposed services but all distinct compose stacks', async () => {
     mockHttpService.get.mockReturnValue(
       of({
         data: [
-          container('portfolio'),
-          container('portfolio'),
-          container('space-server'),
-          container('ghost'),
-          container(), // standalone container, empty Labels
+          container('portfolio'), // exposed
+          container('portfolio'), // exposed
+          container('space-server'), // exposed
+          container('ghost'), // exposed
+          container('monitoring', false), // internal-only stack, no traefik label
+          container(undefined, false), // standalone internal container
           {}, // container summary with no Labels key at all
         ],
       }),
@@ -55,7 +59,9 @@ describe('InfraService', () => {
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: 6, stacks: 3 });
+    // 4 containers carry traefik.enable=true → 4 services; stacks span all
+    // compose projects (portfolio, space-server, ghost, monitoring) → 4.
+    expect(stats).toEqual({ services: 4, stacks: 4 });
     expect(mockHttpService.get).toHaveBeenCalledWith(
       'http://dockerproxy:2375/containers/json',
       expect.objectContaining({ timeout: expect.any(Number) }),
@@ -69,7 +75,7 @@ describe('InfraService', () => {
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: null, stacks: null });
+    expect(stats).toEqual({ services: null, stacks: null });
   });
 
   it('returns zeroes when no containers are running', async () => {
@@ -77,6 +83,6 @@ describe('InfraService', () => {
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: 0, stacks: 0 });
+    expect(stats).toEqual({ services: 0, stacks: 0 });
   });
 });

--- a/src/infra/infra.service.ts
+++ b/src/infra/infra.service.ts
@@ -6,8 +6,8 @@ import type { InfraConfig } from '@config/configuration.types';
 
 /** Live infrastructure counts surfaced on the public SIGNAL panel. */
 export interface InfraStats {
-  /** Running containers, or null when the docker proxy is unreachable. */
-  containers: number | null;
+  /** Traefik-exposed services, or null when the docker proxy is unreachable. */
+  services: number | null;
   /** Distinct docker-compose projects (stacks), or null on failure. */
   stacks: number | null;
 }
@@ -18,6 +18,13 @@ interface DockerContainerSummary {
 }
 
 const COMPOSE_PROJECT_LABEL = 'com.docker.compose.project';
+/**
+ * Traefik's opt-in label. Counting only containers that carry it yields
+ * "services I run" (blog, webmail, dashboards, apps…) rather than the raw
+ * running-container total, which is dominated by internal plumbing —
+ * exporters, cadvisor, db, redis, the docker proxy itself.
+ */
+const TRAEFIK_ENABLE_LABEL = 'traefik.enable';
 const REQUEST_TIMEOUT_MS = 5000;
 
 /**
@@ -48,19 +55,21 @@ export class InfraService {
         ),
       );
 
-      const containers = data.length;
+      const services = data.filter(
+        (c) => c.Labels?.[TRAEFIK_ENABLE_LABEL] === 'true',
+      ).length;
       const stacks = new Set(
         data
           .map((c) => c.Labels?.[COMPOSE_PROJECT_LABEL])
           .filter((project): project is string => Boolean(project)),
       ).size;
 
-      return { containers, stacks };
+      return { services, stacks };
     } catch (error) {
       // Decorative data: never let a proxy outage break the caller — degrade to nulls.
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Failed to fetch docker stats: ${message}`);
-      return { containers: null, stacks: null };
+      return { services: null, stacks: null };
     }
   }
 }


### PR DESCRIPTION
## What

The SIGNAL panel's live infra count sourced **every running container** (37) — including internal plumbing (exporters, cadvisor, mysql, redis, the docker proxy itself). That reads as noise, not "services I run."

This filters `/containers/json` by the `traefik.enable=true` label so the number reflects **publicly-fronted services** (~17 on prod today: blog, webmail, dashboards, portfolio, nova-id, etc.), and renames the API field `containers` → `services` to match its meaning.

`stacks` is unchanged (all distinct compose projects = 12) — an honest total.

## Notes
- ADR-0004 constraint preserved: still only the `/containers/json` LIST endpoint, never inspect.
- Real number can't be asserted in unit tests (mocked); verified the predicate against live docker on the host (37 total → 17 `traefik.enable=true`, 0 `false`, 20 unlabelled).
- Frontend (`portfolio`) relabels CONTAINERS → SERVICES and consumes the renamed field in a paired PR.

## Tests
577 passing; format/lint/build clean.