### PR TITLE
Release 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2026-07-16
+
+### Changed
+- **`GET /infra/stats` counts Traefik-exposed services, not raw containers** — the endpoint now counts only containers labelled `traefik.enable=true` (the services actually fronted by the reverse proxy) instead of every running container, and the response field is renamed `containers` → `services`. The SIGNAL panel now reflects publicly-fronted services (blog, webmail, dashboards, apps) rather than internal plumbing (exporters, cadvisor, db, redis, the docker proxy itself). Still uses only the `/containers/json` list endpoint — never inspect — per ADR-0004; `stacks` is unchanged. (#143)
+
+---
+
 ## [2.14.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 <!-- istanbul-badges-readme-start -->
 [![Lines](https://img.shields.io/badge/lines-96.84%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
-[![Statements](https://img.shields.io/badge/statements-96.62%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
+[![Statements](https://img.shields.io/badge/statements-96.63%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
 [![Branches](https://img.shields.io/badge/branches-91.08%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
-[![Functions](https://img.shields.io/badge/functions-93.33%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
+[![Functions](https://img.shields.io/badge/functions-93.35%25-brightgreen.svg?style=flat)](https://github.com/cativo23/portfolio-api)
 <!-- istanbul-badges-readme-end -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D23.0.0-brightgreen.svg)](https://nodejs.org/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Production NestJS REST API — JWT auth, TypeORM, rate limiting, Docker, 90%+ test coverage",
   "author": "",
   "private": true,

--- a/src/infra/dto/infra-stats-response.dto.ts
+++ b/src/infra/dto/infra-stats-response.dto.ts
@@ -6,11 +6,11 @@ import { ApiProperty } from '@nestjs/swagger';
  */
 export class InfraStatsResponseDto {
   @ApiProperty({
-    description: 'Number of running containers',
+    description: 'Number of Traefik-exposed services',
     nullable: true,
-    example: 20,
+    example: 17,
   })
-  containers: number | null;
+  services: number | null;
 
   @ApiProperty({
     description: 'Number of distinct docker-compose projects (stacks)',

--- a/src/infra/infra.controller.spec.ts
+++ b/src/infra/infra.controller.spec.ts
@@ -36,10 +36,10 @@ describe('InfraController', () => {
   });
 
   it('returns the stats from the service', async () => {
-    mockInfraService.getStats.mockResolvedValue({ containers: 20, stacks: 12 });
+    mockInfraService.getStats.mockResolvedValue({ services: 17, stacks: 12 });
 
     await expect(controller.stats()).resolves.toEqual({
-      containers: 20,
+      services: 17,
       stacks: 12,
     });
     expect(mockInfraService.getStats).toHaveBeenCalledTimes(1);
@@ -47,12 +47,12 @@ describe('InfraController', () => {
 
   it('passes null counts through unchanged when the source is unreachable', async () => {
     mockInfraService.getStats.mockResolvedValue({
-      containers: null,
+      services: null,
       stacks: null,
     });
 
     await expect(controller.stats()).resolves.toEqual({
-      containers: null,
+      services: null,
       stacks: null,
     });
   });

--- a/src/infra/infra.controller.ts
+++ b/src/infra/infra.controller.ts
@@ -11,8 +11,8 @@ const INFRA_CACHE_TTL_MS = 5 * 60 * 1000;
 /**
  * Public infrastructure signal for the portfolio's SIGNAL panel.
  *
- * Exposes only aggregate counts (running containers, compose stacks) — the same
- * numbers rendered publicly on the site — so there is no new information exposure.
+ * Exposes only aggregate counts (Traefik-exposed services, compose stacks) — the
+ * same numbers rendered publicly on the site — so there is no new information exposure.
  */
 @ApiTags('Infra')
 @Controller('infra')
@@ -25,9 +25,9 @@ export class InfraController {
   @CacheKey('infra:stats')
   @CacheTTL(INFRA_CACHE_TTL_MS)
   @ApiOperation({
-    summary: 'Live container and stack counts',
+    summary: 'Live service and stack counts',
     description:
-      'Running-container and docker-compose-stack counts derived from the ' +
+      'Traefik-exposed-service and docker-compose-stack counts derived from the ' +
       'read-only docker-socket-proxy. Fields are null if the source is unreachable.',
   })
   @ApiResponse({

--- a/src/infra/infra.service.spec.ts
+++ b/src/infra/infra.service.spec.ts
@@ -15,8 +15,11 @@ const mockConfigService = {
   }),
 };
 
-function container(project?: string) {
-  return { Labels: project ? { 'com.docker.compose.project': project } : {} };
+function container(project?: string, exposed = true) {
+  const labels: Record<string, string> = {};
+  if (project) labels['com.docker.compose.project'] = project;
+  if (exposed) labels['traefik.enable'] = 'true';
+  return { Labels: labels };
 }
 
 describe('InfraService', () => {
@@ -39,15 +42,16 @@ describe('InfraService', () => {
     service = module.get<InfraService>(InfraService);
   });
 
-  it('counts running containers and distinct compose stacks', async () => {
+  it('counts only Traefik-exposed services but all distinct compose stacks', async () => {
     mockHttpService.get.mockReturnValue(
       of({
         data: [
-          container('portfolio'),
-          container('portfolio'),
-          container('space-server'),
-          container('ghost'),
-          container(), // standalone container, empty Labels
+          container('portfolio'), // exposed
+          container('portfolio'), // exposed
+          container('space-server'), // exposed
+          container('ghost'), // exposed
+          container('monitoring', false), // internal-only stack, no traefik label
+          container(undefined, false), // standalone internal container
           {}, // container summary with no Labels key at all
         ],
       }),
@@ -55,7 +59,9 @@ describe('InfraService', () => {
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: 6, stacks: 3 });
+    // 4 containers carry traefik.enable=true → 4 services; stacks span all
+    // compose projects (portfolio, space-server, ghost, monitoring) → 4.
+    expect(stats).toEqual({ services: 4, stacks: 4 });
     expect(mockHttpService.get).toHaveBeenCalledWith(
       'http://dockerproxy:2375/containers/json',
       expect.objectContaining({ timeout: expect.any(Number) }),
@@ -69,7 +75,7 @@ describe('InfraService', () => {
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: null, stacks: null });
+    expect(stats).toEqual({ services: null, stacks: null });
   });
 
   it('returns zeroes when no containers are running', async () => {
@@ -77,6 +83,6 @@ describe('InfraService', () => {
 
     const stats = await service.getStats();
 
-    expect(stats).toEqual({ containers: 0, stacks: 0 });
+    expect(stats).toEqual({ services: 0, stacks: 0 });
   });
 });

--- a/src/infra/infra.service.ts
+++ b/src/infra/infra.service.ts
@@ -6,8 +6,8 @@ import type { InfraConfig } from '@config/configuration.types';
 
 /** Live infrastructure counts surfaced on the public SIGNAL panel. */
 export interface InfraStats {
-  /** Running containers, or null when the docker proxy is unreachable. */
-  containers: number | null;
+  /** Traefik-exposed services, or null when the docker proxy is unreachable. */
+  services: number | null;
   /** Distinct docker-compose projects (stacks), or null on failure. */
   stacks: number | null;
 }
@@ -18,6 +18,13 @@ interface DockerContainerSummary {
 }
 
 const COMPOSE_PROJECT_LABEL = 'com.docker.compose.project';
+/**
+ * Traefik's opt-in label. Counting only containers that carry it yields
+ * "services I run" (blog, webmail, dashboards, apps…) rather than the raw
+ * running-container total, which is dominated by internal plumbing —
+ * exporters, cadvisor, db, redis, the docker proxy itself.
+ */
+const TRAEFIK_ENABLE_LABEL = 'traefik.enable';
 const REQUEST_TIMEOUT_MS = 5000;
 
 /**
@@ -48,19 +55,21 @@ export class InfraService {
         ),
       );
 
-      const containers = data.length;
+      const services = data.filter(
+        (c) => c.Labels?.[TRAEFIK_ENABLE_LABEL] === 'true',
+      ).length;
       const stacks = new Set(
         data
           .map((c) => c.Labels?.[COMPOSE_PROJECT_LABEL])
           .filter((project): project is string => Boolean(project)),
       ).size;
 
-      return { containers, stacks };
+      return { services, stacks };
     } catch (error) {
       // Decorative data: never let a proxy outage break the caller — degrade to nulls.
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Failed to fetch docker stats: ${message}`);
-      return { containers: null, stacks: null };
+      return { services: null, stacks: null };
     }
   }
 }


### PR DESCRIPTION
## Summary

The `/infra/stats` endpoint now counts only Traefik-exposed services instead of all running containers, reflecting the publicly-fronted services in the SIGNAL panel and excluding internal infrastructure components.

## Highlights

- **`GET /infra/stats` counts Traefik-exposed services, not raw containers** — the endpoint now counts only containers labelled `traefik.enable=true` (the services actually fronted by the reverse proxy) instead of every running container, and the response field is renamed `containers` → `services`. The SIGNAL panel now reflects publicly-fronted services (blog, webmail, dashboards, apps) rather than internal plumbing (exporters, cadvisor, db, redis, the docker proxy itself). Still uses only the `/containers/json` list endpoint — never inspect — per ADR-0004; `stacks` is unchanged. (#143)

## Test plan

- [x] CI \`build\` green on source PRs
- [ ] Post-merge: auto-release tags \`v2.15.0\` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: \`curl -I https://api.cativo.dev/\` shows expected headers
- [ ] Post-deploy: container reports \`healthy\`
- [ ] Post-release: \`main\` merged back to \`develop\`

Refs #143