### PR TITLE
fix(auth): return 401 not 500 when stored password is missing

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -133,6 +133,23 @@ describe('AuthService', () => {
         service.validateUser(user.email, 'wrongpass'),
       ).rejects.toThrow(AuthenticationException);
     });
+
+    it('should throw AuthenticationException (not 500) if the stored password is missing', async () => {
+      // A user inserted directly into the DB without going through
+      // UsersService.create() can have a null/undefined password. bcrypt.compare
+      // throws "data and hash arguments required" on such a hash, which would
+      // otherwise surface as a 500 instead of a clean 401.
+      const user = {
+        id: 1,
+        email: 'test@mail.com',
+        password: undefined,
+      } as unknown as User;
+      usersService.findOneByEmail.mockResolvedValue(user);
+
+      await expect(service.validateUser(user.email, password)).rejects.toThrow(
+        AuthenticationException,
+      );
+    });
   });
 
   describe('login', () => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -47,8 +47,7 @@ export class AuthService {
    * @param email - User's email address
    * @param password - User's password
    * @returns Promise resolving to an object containing the access token, expiration time, and user information
-   * @throws NotFoundException if the user is not found
-   * @throws AuthenticationException if the password is incorrect
+   * @throws AuthenticationException if the user is not found or the password is incorrect
    */
   async login(
     email: string,
@@ -92,13 +91,15 @@ export class AuthService {
    * @param email - User's email address
    * @param password - User's password
    * @returns Promise resolving to the user entity if validation is successful
-   * @throws NotFoundException if the user is not found
-   * @throws AuthenticationException if the password is incorrect
+   * @throws AuthenticationException if the user is not found or the password is incorrect
    */
   async validateUser(email: string, password: string): Promise<User> {
     const user = await this.usersService.findOneByEmail(email);
-    if (!user) {
-      // Same error message as invalid password to prevent user enumeration
+    if (!user || !user.password) {
+      // Also covers users inserted directly into the DB without a hashed
+      // password: bcrypt.compare throws on a null/undefined hash, which would
+      // otherwise surface as a 500 instead of a clean 401. Same message as an
+      // incorrect password to prevent user enumeration.
       throw new AuthenticationException('Invalid email or password');
     }
     const isMatch: boolean = await bcrypt.compare(password, user.password);


### PR DESCRIPTION
## What
`validateUser` now guards a missing/null stored password hash before calling `bcrypt.compare`, returning a clean, enumeration-safe **401** instead of letting bcrypt throw `"data and hash arguments required"` → **500**.

## Why
Roadmap hygiene item #6 reported "`/auth/login` 500s on unknown user." Investigation showed the *unknown-user* path already returns 401 (`findOneByEmail`→`undefined`). The real 500 fires for an **existing** user whose `password` is null/undefined — reachable only via direct DB inserts that bypass `UsersService.create()` (which hashes). Matches the local `ccativo@mibluemedical.com` row inserted unhashed during earlier dev work. Low severity in prod, but a genuine correctness bug.

## How
- `if (!user || !user.password)` → `AuthenticationException` (same message as bad password, no enumeration leak).
- Corrected stale `@throws NotFoundException` JSDoc on `validateUser`/`login`.

## Tests
- TDD: added a regression spec (null-password user → `AuthenticationException`), confirmed red before the fix.
- Full suite **578/578** green, typecheck + prettier clean.