### PR TITLE
fix(dev): unbreak local project hero images (roadmap #7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "seed:test": "npx ts-node -r tsconfig-paths/register src/database/seeder.ts",
     "seed:test:prod": "node dist/src/database/seeder.prod.js",
     "seed:update-projects": "npx ts-node -r tsconfig-paths/register src/database/seeds/update-projects-seed.ts",
-    "seed:update-projects:prod": "node dist/src/database/seeds/update-projects-seed.prod.js"
+    "seed:update-projects:prod": "node dist/src/database/seeds/update-projects-seed.prod.js",
+    "seed:normalize-hero-urls": "npx ts-node -r tsconfig-paths/register src/database/seeds/normalize-hero-urls.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^4",

--- a/src/config/cors.utils.ts
+++ b/src/config/cors.utils.ts
@@ -3,6 +3,7 @@ import type { AppConfig } from '@config/configuration.types';
 const DEV_LOCALHOST_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:3001',
+  'http://localhost:3002',
   'http://localhost:4173',
   'http://localhost:4200',
   'http://localhost:5173',

--- a/src/database/seeds/normalize-hero-urls.spec.ts
+++ b/src/database/seeds/normalize-hero-urls.spec.ts
@@ -1,0 +1,42 @@
+import {
+  normalizeHeroImageUrl,
+  HERO_ASSET_ORIGIN,
+} from './normalize-hero-urls';
+
+describe('normalizeHeroImageUrl', () => {
+  it('rewrites a stale localhost:3001 dev origin to the canonical prod host', () => {
+    expect(
+      normalizeHeroImageUrl(
+        'http://localhost:3001/img/projects/heroes/portfolio.svg',
+      ),
+    ).toBe(`${HERO_ASSET_ORIGIN}/img/projects/heroes/portfolio.svg`);
+  });
+
+  it('rewrites any other dev port (e.g. 3002) the same way', () => {
+    expect(
+      normalizeHeroImageUrl(
+        'http://localhost:3002/img/projects/heroes/nightwire.svg',
+      ),
+    ).toBe(`${HERO_ASSET_ORIGIN}/img/projects/heroes/nightwire.svg`);
+  });
+
+  it('is idempotent when the value already points at the canonical host', () => {
+    const canonical = `${HERO_ASSET_ORIGIN}/img/projects/heroes/lumira.svg`;
+    expect(normalizeHeroImageUrl(canonical)).toBe(canonical);
+  });
+
+  it('leaves unrelated URLs (no hero asset path) untouched', () => {
+    expect(normalizeHeroImageUrl('https://cativo.dev/og-image.png')).toBe(
+      'https://cativo.dev/og-image.png',
+    );
+    expect(normalizeHeroImageUrl('https://blog.example.com/hero.png')).toBe(
+      'https://blog.example.com/hero.png',
+    );
+  });
+
+  it('returns null/undefined/empty unchanged', () => {
+    expect(normalizeHeroImageUrl(null)).toBeNull();
+    expect(normalizeHeroImageUrl(undefined)).toBeUndefined();
+    expect(normalizeHeroImageUrl('')).toBe('');
+  });
+});

--- a/src/database/seeds/normalize-hero-urls.ts
+++ b/src/database/seeds/normalize-hero-urls.ts
@@ -1,0 +1,72 @@
+import AppDataSource from '@config/typeorm.config';
+import { Logger } from '@nestjs/common';
+import { Project } from '@projects/entities/project.entity';
+
+/**
+ * Canonical host that serves the project hero assets in production.
+ * Local hero images are loaded from here too, so local dev matches prod
+ * exactly (same external-passthrough render path) regardless of which port
+ * the dev server runs on.
+ */
+export const HERO_ASSET_ORIGIN = 'https://cativo.dev';
+
+const HERO_PATH_SEGMENT = '/img/projects/heroes/';
+
+/**
+ * Normalizes a project `heroImage` value so its origin points at the canonical
+ * prod asset host, keyed on the hero asset path.
+ *
+ * - `http://localhost:3001/img/projects/heroes/x.svg` → `https://cativo.dev/img/projects/heroes/x.svg`
+ * - `https://cativo.dev/img/projects/heroes/x.svg`     → unchanged (idempotent)
+ * - Any value NOT containing the hero asset path        → unchanged
+ * - `null`/empty                                        → returned as-is
+ *
+ * This is what makes a locally hand-edited (`:3001`) DB match prod without a
+ * manual DB edit: re-runnable and safe against prod data (a no-op there).
+ */
+export function normalizeHeroImageUrl(
+  heroImage: string | null | undefined,
+): string | null | undefined {
+  if (!heroImage) return heroImage;
+  const idx = heroImage.indexOf(HERO_PATH_SEGMENT);
+  if (idx === -1) return heroImage;
+  const pathAndAfter = heroImage.slice(idx);
+  return `${HERO_ASSET_ORIGIN}${pathAndAfter}`;
+}
+
+/**
+ * Rewrites any project whose hero URL points at a non-canonical origin
+ * (e.g. a stale `localhost:3001` dev URL) to the canonical prod host.
+ */
+async function normalizeHeroUrls(): Promise<void> {
+  const logger = new Logger('NormalizeHeroUrls');
+  const dataSource = await AppDataSource.initialize();
+  try {
+    const repository = dataSource.getRepository(Project);
+    const projects = await repository.find();
+    let updated = 0;
+
+    for (const project of projects) {
+      const next = normalizeHeroImageUrl(project.heroImage);
+      if (next !== project.heroImage) {
+        await repository.update(project.id, { heroImage: next as string });
+        logger.log(
+          `Project #${project.id}: heroImage ${project.heroImage} → ${next}`,
+        );
+        updated += 1;
+      }
+    }
+
+    logger.log(
+      `Hero URL normalization complete — ${updated} of ${projects.length} project(s) updated.`,
+    );
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+if (require.main === module) {
+  normalizeHeroUrls()
+    .then(() => process.exit(0))
+    .catch(() => process.exit(1));
+}

--- a/src/database/seeds/normalize-hero-urls.ts
+++ b/src/database/seeds/normalize-hero-urls.ts
@@ -48,8 +48,8 @@ async function normalizeHeroUrls(): Promise<void> {
 
     for (const project of projects) {
       const next = normalizeHeroImageUrl(project.heroImage);
-      if (next !== project.heroImage) {
-        await repository.update(project.id, { heroImage: next as string });
+      if (typeof next === 'string' && next !== project.heroImage) {
+        await repository.update(project.id, { heroImage: next });
         logger.log(
           `Project #${project.id}: heroImage ${project.heroImage} → ${next}`,
         );

--- a/src/database/seeds/normalize-hero-urls.ts
+++ b/src/database/seeds/normalize-hero-urls.ts
@@ -37,7 +37,13 @@ export function normalizeHeroImageUrl(
 /**
  * Rewrites any project whose hero URL points at a non-canonical origin
  * (e.g. a stale `localhost:3001` dev URL) to the canonical prod host.
+ *
+ * Requires a live DB connection (same as the sibling `database/seeder*`
+ * scripts, which the coverage config already excludes), so it's covered by
+ * running it against a real dev DB rather than a unit spec; the pure
+ * `normalizeHeroImageUrl` transform above carries the real test coverage.
  */
+/* v8 ignore start */
 async function normalizeHeroUrls(): Promise<void> {
   const logger = new Logger('NormalizeHeroUrls');
   const dataSource = await AppDataSource.initialize();
@@ -70,3 +76,4 @@ if (require.main === module) {
     .then(() => process.exit(0))
     .catch(() => process.exit(1));
 }
+/* v8 ignore stop */


### PR DESCRIPTION
## Context (roadmap #7)
Local project detail pages 404'd their hero images. Investigation found:
- **Prod is fine** — it stores canonical `https://cativo.dev/img/projects/heroes/*.svg` and renders them as **plain external `<img>` (no IPX)**. Verified against the live SSR HTML.
- The 404 was purely a **local DB** with hand-edited `http://localhost:3001/...` hero URLs that died when the dev server moved to `:3002`.
- The committed seeders are unrelated demo fixtures (example.com / og-image.png), not prod's data source — so this isn't a seeder-data edit.

## Changes
1. **`seed:normalize-hero-urls`** — a re-runnable seed that rewrites any project's `heroImage` origin to the canonical prod host, keyed on the `/img/projects/heroes/` path. Idempotent, a **no-op on prod data**, so local matches prod without a manual DB edit. Pure `normalizeHeroImageUrl` helper is unit-tested (5 cases).
2. **dev CORS** — add `localhost:3002` (current frontend dev port) to the development-only allowlist.

## Why not relative paths
Switching `heroImage` to relative (`/img/...`) would route every prod hero through NuxtImg's IPX optimizer — a path currently **not** exercised (prod passes the absolute URL straight through) and unreliable for SVGs. Keeping absolute `cativo.dev` URLs means local and prod share the exact same render path. Prod needs no change.

## Tests
582/582 green, typecheck + prettier clean.