### PR TITLE
🚀 Release 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.1] - 2026-07-23
+
+### Fixed
+- **Stale lumira/nightwire download counts in chat grounding data** — the chatbot's profile grounding still said lumira ~3.4K/mo and nightwire ~475/mo. Corrected to the verified live npm registry numbers (~1.8K/mo and ~84/mo respectively). (#150)
+
+---
+
 ## [2.17.0] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio-api",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Production NestJS REST API — JWT auth, TypeORM, rate limiting, Docker, 90%+ test coverage",
   "author": "",
   "private": true,

--- a/src/profile/profile-grounding.ts
+++ b/src/profile/profile-grounding.ts
@@ -184,13 +184,13 @@ export const CARLOS_GROUNDING: GroundingProfile = {
   openSource: [
     {
       name: 'lumira',
-      downloads: '~3.4K downloads/mo',
+      downloads: '~1.8K downloads/mo',
       description:
         'Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection. Zero deps. TypeScript, npm.',
     },
     {
       name: 'nightwire',
-      downloads: '~475 downloads/mo',
+      downloads: '~84 downloads/mo',
       description:
         'Dark cyberpunk UI design system. Semantic color roles, neon palette, CLI installer. CSS, npm.',
     },


### PR DESCRIPTION
## Summary

Patch release fixing stale lumira/nightwire download counts in the chat grounding data. The chatbot's profile grounding was still referencing outdated npm registry numbers; now aligned with current live data.

## Highlights

- **Stale lumira/nightwire download counts in chat grounding data** — the chatbot's profile grounding still said lumira ~3.4K/mo and nightwire ~475/mo. Corrected to the verified live npm registry numbers (~1.8K/mo and ~84/mo respectively). (#150)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v2.17.1` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://api.cativo.dev/health` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`

Refs #150